### PR TITLE
Add dashboard analytics view with filters and charts

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,99 @@ const randomNotes = [
   'Review module warmup behavior before next run.'
 ];
 
+const videoLibrary = [
+  {
+    id: 'vid-01',
+    name: 'A系列 • 500g • 旋盖 • 皮带输送',
+    line: '1号线',
+    modelSeries: 'A系列',
+    fillWeight: '500g',
+    capping: '旋盖',
+    conveying: '皮带输送',
+    buffering: '缓存仓',
+    voc: '需要',
+    explosion: '非防爆',
+    metrics: { efficiency: 88, quality: 92, uptime: 95 },
+    src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+    description: 'A系列500g皮带输送线，常规旋盖与VOC治理方案。'
+  },
+  {
+    id: 'vid-02',
+    name: 'A系列 • 1kg • 压盖 • 链板输送',
+    line: '2号线',
+    modelSeries: 'A系列',
+    fillWeight: '1kg',
+    capping: '压盖',
+    conveying: '链板输送',
+    buffering: '缓存仓',
+    voc: '需要',
+    explosion: '防爆',
+    metrics: { efficiency: 82, quality: 90, uptime: 92 },
+    src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+    description: '重量升级至1kg的A系列线，带压盖及防爆处理。'
+  },
+  {
+    id: 'vid-03',
+    name: 'B系列 • 500g • 旋盖 • 滚筒输送',
+    line: '3号线',
+    modelSeries: 'B系列',
+    fillWeight: '500g',
+    capping: '旋盖',
+    conveying: '滚筒输送',
+    buffering: '缓存塔',
+    voc: '免除',
+    explosion: '非防爆',
+    metrics: { efficiency: 91, quality: 95, uptime: 97 },
+    src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+    description: 'B系列旋盖线，滚筒输送并采用立式缓存塔方案。'
+  },
+  {
+    id: 'vid-04',
+    name: 'B系列 • 750g • 压盖 • 皮带输送',
+    line: '4号线',
+    modelSeries: 'B系列',
+    fillWeight: '750g',
+    capping: '压盖',
+    conveying: '皮带输送',
+    buffering: '缓存仓',
+    voc: '免除',
+    explosion: '防爆',
+    metrics: { efficiency: 85, quality: 88, uptime: 90 },
+    src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+    description: 'B系列中量级压盖线，配置皮带输送与防爆电控。'
+  },
+  {
+    id: 'vid-05',
+    name: 'C系列 • 1kg • 旋盖 • 链板输送',
+    line: '5号线',
+    modelSeries: 'C系列',
+    fillWeight: '1kg',
+    capping: '旋盖',
+    conveying: '链板输送',
+    buffering: '缓存塔',
+    voc: '需要',
+    explosion: '非防爆',
+    metrics: { efficiency: 79, quality: 87, uptime: 89 },
+    src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+    description: 'C系列多变配方线，链板输送搭配塔式缓存。'
+  },
+  {
+    id: 'vid-06',
+    name: 'C系列 • 750g • 压盖 • 滚筒输送',
+    line: '6号线',
+    modelSeries: 'C系列',
+    fillWeight: '750g',
+    capping: '压盖',
+    conveying: '滚筒输送',
+    buffering: '缓存仓',
+    voc: '免除',
+    explosion: '防爆',
+    metrics: { efficiency: 83, quality: 86, uptime: 91 },
+    src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+    description: 'C系列压盖防爆线，滚筒输送专注安全联锁。'
+  }
+];
+
 const Store = {
   load() {
     try {
@@ -180,9 +273,24 @@ const App = (() => {
   let state = Store.load();
   let selection = { group: 'lines', id: state.lines[0].id };
   let currentVideoElement;
+  const filterKeys = ['modelSeries', 'fillWeight', 'capping', 'conveying', 'buffering', 'voc', 'explosion'];
+  const metricKeys = ['efficiency', 'quality', 'uptime'];
+  const metricLabels = ['效率', '质量', '稼动率'];
+  const fillWeightCategories = ['500g', '750g', '1kg'].filter(weight =>
+    videoLibrary.some(video => video.fillWeight === weight)
+  );
+  let dashboardFilters = filterKeys.reduce((acc, key) => ({ ...acc, [key]: 'all' }), {});
+  let dashboardSelection = null;
+  let weightChart;
+  let radarChart;
 
   const refs = {
     shell: document.querySelector('.app-shell'),
+    navButtons: Array.from(document.querySelectorAll('[data-view-target]')),
+    views: {
+      video: document.querySelector('[data-view="video"]'),
+      dashboard: document.querySelector('[data-view="dashboard"]')
+    },
     modeButtons: Array.from(document.querySelectorAll('.mode-toggle__btn')),
     dashboardContainers: {
       lines: document.getElementById('lines-dashboard'),
@@ -215,11 +323,25 @@ const App = (() => {
       reset: document.querySelector('[data-action="reset"]')
     },
     paneEditButtons: Array.from(document.querySelectorAll('.pane-edit-btn')),
-    videoControls: document.querySelector('.video-controls')
+    videoControls: document.querySelector('.video-controls'),
+    dashboard: {
+      filters: filterKeys.reduce((acc, key) => {
+        acc[key] = document.querySelector(`[data-filter="${key}"]`);
+        return acc;
+      }, {}),
+      results: document.getElementById('dashboard-results'),
+      chart: document.getElementById('dashboard-chart'),
+      radar: document.getElementById('dashboard-radar'),
+      previewVideo: document.getElementById('dashboard-preview-video'),
+      previewName: document.getElementById('dashboard-preview-name'),
+      previewMeta: document.getElementById('dashboard-preview-meta')
+    }
   };
 
   function init() {
     currentVideoElement = refs.video;
+    setupNavigation();
+    initDashboard();
     updateMode(state.mode || 'presenter', { save: false });
     refs.modeButtons.forEach(btn => btn.addEventListener('click', () => updateMode(btn.dataset.mode)));
     bindTopBarActions();
@@ -307,6 +429,241 @@ const App = (() => {
       });
     });
     refreshActiveCard();
+  }
+
+  function setupNavigation() {
+    refs.navButtons.forEach(btn => {
+      btn.addEventListener('click', () => switchView(btn.dataset.viewTarget));
+    });
+  }
+
+  function switchView(target) {
+    const view = refs.views[target];
+    if (!view) return;
+    Object.values(refs.views).forEach(element => {
+      const isActive = element === view;
+      element.classList.toggle('is-active', isActive);
+      if (isActive) {
+        element.removeAttribute('hidden');
+      } else {
+        element.setAttribute('hidden', 'hidden');
+      }
+    });
+    refs.navButtons.forEach(btn => {
+      btn.classList.toggle('is-active', btn.dataset.viewTarget === target);
+    });
+    if (target === 'dashboard') {
+      renderDashboard();
+    }
+  }
+
+  function initDashboard() {
+    populateFilterOptions();
+    attachFilterEvents();
+    renderDashboard();
+  }
+
+  function populateFilterOptions() {
+    Object.entries(refs.dashboard.filters).forEach(([key, select]) => {
+      if (!select) return;
+      let uniqueValues = Array.from(new Set(videoLibrary.map(video => video[key])));
+      if (key === 'fillWeight') {
+        uniqueValues = fillWeightCategories;
+      } else {
+        uniqueValues = uniqueValues.sort((a, b) => a.localeCompare(b, 'zh-Hans-CN'));
+      }
+      select.innerHTML = '';
+      const allOption = new Option('全部', 'all');
+      select.appendChild(allOption);
+      uniqueValues.forEach(value => {
+        const option = new Option(value, value);
+        select.appendChild(option);
+      });
+      select.value = 'all';
+      dashboardFilters[key] = 'all';
+    });
+  }
+
+  function attachFilterEvents() {
+    Object.entries(refs.dashboard.filters).forEach(([key, select]) => {
+      if (!select) return;
+      select.addEventListener('change', () => {
+        dashboardFilters[key] = select.value;
+        renderDashboard();
+      });
+    });
+  }
+
+  function getFilteredVideos() {
+    return videoLibrary.filter(video =>
+      filterKeys.every(key => {
+        const filterValue = dashboardFilters[key];
+        return filterValue === 'all' || video[key] === filterValue;
+      })
+    );
+  }
+
+  function renderDashboard() {
+    const filtered = getFilteredVideos();
+    updateDashboardResults(filtered);
+    updateCharts(filtered);
+  }
+
+  function updateDashboardResults(filtered) {
+    const list = refs.dashboard.results;
+    if (!list) return;
+    list.innerHTML = '';
+    if (!filtered.length) {
+      const empty = document.createElement('li');
+      empty.className = 'dashboard-results__item';
+      empty.textContent = '未找到匹配的视频，请调整过滤条件。';
+      list.appendChild(empty);
+      dashboardSelection = null;
+      updatePreview(null);
+      return;
+    }
+
+    if (!dashboardSelection || !filtered.some(video => video.id === dashboardSelection)) {
+      dashboardSelection = filtered[0].id;
+    }
+
+    filtered.forEach(video => {
+      const item = document.createElement('li');
+      item.className = 'dashboard-results__item';
+      if (video.id === dashboardSelection) {
+        item.classList.add('is-active');
+      }
+      const button = document.createElement('button');
+      button.type = 'button';
+      const title = document.createElement('h3');
+      title.className = 'dashboard-results__title';
+      title.textContent = video.name;
+      const metaPrimary = document.createElement('p');
+      metaPrimary.className = 'dashboard-results__meta';
+      metaPrimary.textContent = `${video.line} • ${video.modelSeries} • ${video.fillWeight} • ${video.capping}`;
+      const metaSecondary = document.createElement('p');
+      metaSecondary.className = 'dashboard-results__meta';
+      metaSecondary.textContent = `${video.conveying} • ${video.buffering} • VOC: ${video.voc} • ${video.explosion}`;
+      const metricLine = document.createElement('p');
+      metricLine.className = 'dashboard-results__meta';
+      metricLine.textContent = `效率 ${video.metrics.efficiency}% ｜ 质量 ${video.metrics.quality}% ｜ 稼动率 ${video.metrics.uptime}%`;
+
+      button.append(title, metaPrimary, metaSecondary, metricLine);
+      button.addEventListener('click', () => {
+        dashboardSelection = video.id;
+        list.querySelectorAll('.dashboard-results__item').forEach(node => {
+          node.classList.toggle('is-active', node === item);
+        });
+        updatePreview(video);
+      });
+      item.appendChild(button);
+      list.appendChild(item);
+    });
+
+    const activeVideo = filtered.find(video => video.id === dashboardSelection);
+    updatePreview(activeVideo);
+  }
+
+  function updateCharts(filtered) {
+    if (typeof Chart === 'undefined' || !refs.dashboard.chart || !refs.dashboard.radar) {
+      return;
+    }
+    const counts = fillWeightCategories.map(weight =>
+      filtered.filter(video => video.fillWeight === weight).length
+    );
+    if (!weightChart) {
+      weightChart = new Chart(refs.dashboard.chart.getContext('2d'), {
+        type: 'bar',
+        data: {
+          labels: fillWeightCategories,
+          datasets: [
+            {
+              label: '视频数量',
+              data: counts,
+              backgroundColor: 'rgba(37, 99, 235, 0.55)',
+              borderRadius: 12,
+              maxBarThickness: 48
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          plugins: {
+            legend: { display: false }
+          },
+          scales: {
+            y: {
+              beginAtZero: true,
+              ticks: {
+                precision: 0
+              }
+            }
+          }
+        }
+      });
+    } else {
+      weightChart.data.labels = fillWeightCategories;
+      weightChart.data.datasets[0].data = counts;
+      weightChart.update();
+    }
+
+    const radarData = metricKeys.map(key => {
+      if (!filtered.length) return 0;
+      const total = filtered.reduce((sum, video) => sum + (video.metrics?.[key] ?? 0), 0);
+      return Number((total / filtered.length).toFixed(1));
+    });
+
+    if (!radarChart) {
+      radarChart = new Chart(refs.dashboard.radar.getContext('2d'), {
+        type: 'radar',
+        data: {
+          labels: metricLabels,
+          datasets: [
+            {
+              label: '平均指标',
+              data: radarData,
+              backgroundColor: 'rgba(37, 99, 235, 0.2)',
+              borderColor: 'rgba(37, 99, 235, 0.8)',
+              pointBackgroundColor: 'rgba(37, 99, 235, 1)'
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          scales: {
+            r: {
+              suggestedMin: 0,
+              suggestedMax: 100,
+              ticks: {
+                stepSize: 20
+              }
+            }
+          }
+        }
+      });
+    } else {
+      radarChart.data.datasets[0].data = radarData;
+      radarChart.update();
+    }
+  }
+
+  function updatePreview(video) {
+    if (!refs.dashboard.previewVideo || !refs.dashboard.previewName || !refs.dashboard.previewMeta) {
+      return;
+    }
+    if (!video) {
+      refs.dashboard.previewVideo.removeAttribute('src');
+      refs.dashboard.previewVideo.load();
+      refs.dashboard.previewName.textContent = '无匹配视频';
+      refs.dashboard.previewMeta.textContent = '请调整筛选条件以查看生产视频。';
+      return;
+    }
+    if (refs.dashboard.previewVideo.src !== video.src) {
+      refs.dashboard.previewVideo.src = video.src;
+      refs.dashboard.previewVideo.load();
+    }
+    refs.dashboard.previewName.textContent = video.name;
+    refs.dashboard.previewMeta.textContent = `${video.line} ｜ ${video.modelSeries} ｜ ${video.fillWeight} ｜ ${video.capping} ｜ ${video.conveying} ｜ ${video.buffering} ｜ VOC: ${video.voc} ｜ ${video.explosion}`;
   }
 
   function attachDashboardEvents() {

--- a/index.html
+++ b/index.html
@@ -37,132 +37,233 @@
         </div>
       </header>
 
-      <div class="layout">
-        <aside class="sidebar" aria-label="Dashboards">
-          <section class="dashboard" data-group="lines">
-            <header class="dashboard__header">
-              <h2>Production Lines</h2>
-              <p>9 monitored lines with summary stats</p>
-            </header>
-            <div class="dashboard__grid" id="lines-dashboard" role="list"></div>
-          </section>
-          <section class="dashboard" data-group="feeds">
-            <header class="dashboard__header">
-              <h2>Feed Methods</h2>
-              <p>9 active feed methods to audit</p>
-            </header>
-            <div class="dashboard__grid" id="feeds-dashboard" role="list"></div>
-          </section>
-        </aside>
+      <nav class="primary-nav" aria-label="视图切换">
+        <button class="primary-nav__btn is-active" type="button" data-view-target="video">视频管理</button>
+        <button class="primary-nav__btn" type="button" data-view-target="dashboard">仪表板</button>
+      </nav>
 
-        <main class="detail-pane" aria-live="polite">
-          <section class="video-pane" aria-labelledby="video-pane-title">
-            <div class="video-pane__header">
-              <h2 id="video-pane-title">Video Review</h2>
-              <div class="video-pane__summary-toggle">
-                <label class="switch">
-                  <input id="summary-toggle" type="checkbox" />
-                  <span class="switch__slider" aria-hidden="true"></span>
-                  <span class="switch__label">Set as summary source</span>
-                </label>
-              </div>
-            </div>
-            <div class="video-pane__player">
-              <div id="upload-dropzone" class="video-dropzone" tabindex="0">
-                <p class="video-dropzone__text">Drop MP4 here or</p>
-                <button id="video-upload-btn" type="button" class="pill-btn">Upload video</button>
-                <input id="video-input" class="visually-hidden" type="file" accept="video/mp4" />
-              </div>
-              <div class="video-wrapper">
-                <video id="video-element" playsinline></video>
-                <div class="video-controls" aria-label="Video controls">
-                  <button type="button" data-control="play">Play</button>
-                  <button type="button" data-control="pause">Pause</button>
-                  <button type="button" data-control="mute">Mute</button>
-                  <label>
-                    Volume
-                    <input type="range" data-control="volume" min="0" max="1" step="0.05" value="1" />
+      <div class="view view--video is-active" data-view="video">
+        <div class="layout">
+          <aside class="sidebar" aria-label="Dashboards">
+            <section class="dashboard" data-group="lines">
+              <header class="dashboard__header">
+                <h2>Production Lines</h2>
+                <p>9 monitored lines with summary stats</p>
+              </header>
+              <div class="dashboard__grid" id="lines-dashboard" role="list"></div>
+            </section>
+            <section class="dashboard" data-group="feeds">
+              <header class="dashboard__header">
+                <h2>Feed Methods</h2>
+                <p>9 active feed methods to audit</p>
+              </header>
+              <div class="dashboard__grid" id="feeds-dashboard" role="list"></div>
+            </section>
+          </aside>
+
+          <main class="detail-pane" aria-live="polite">
+            <section class="video-pane" aria-labelledby="video-pane-title">
+              <div class="video-pane__header">
+                <h2 id="video-pane-title">Video Review</h2>
+                <div class="video-pane__summary-toggle">
+                  <label class="switch">
+                    <input id="summary-toggle" type="checkbox" />
+                    <span class="switch__slider" aria-hidden="true"></span>
+                    <span class="switch__label">Set as summary source</span>
                   </label>
-                  <label>
-                    Speed
-                    <select data-control="speed">
-                      <option value="0.5">0.5x</option>
-                      <option value="0.75">0.75x</option>
-                      <option value="1" selected>1x</option>
-                      <option value="1.25">1.25x</option>
-                      <option value="1.5">1.5x</option>
-                      <option value="2">2x</option>
-                    </select>
-                  </label>
-                  <button type="button" data-control="fullscreen">Fullscreen</button>
-                  <button type="button" data-control="poster">Capture poster</button>
                 </div>
               </div>
-            </div>
-            <div class="video-pane__playlist" aria-label="Video playlist">
-              <h3>Playlist</h3>
-              <div id="playlist" class="playlist" role="list"></div>
-            </div>
-            <button class="metadata-toggle" type="button" data-action="metadata">Metadata drawer</button>
-          </section>
+              <div class="video-pane__player">
+                <div id="upload-dropzone" class="video-dropzone" tabindex="0">
+                  <p class="video-dropzone__text">Drop MP4 here or</p>
+                  <button id="video-upload-btn" type="button" class="pill-btn">Upload video</button>
+                  <input id="video-input" class="visually-hidden" type="file" accept="video/mp4" />
+                </div>
+                <div class="video-wrapper">
+                  <video id="video-element" playsinline></video>
+                  <div class="video-controls" aria-label="Video controls">
+                    <button type="button" data-control="play">Play</button>
+                    <button type="button" data-control="pause">Pause</button>
+                    <button type="button" data-control="mute">Mute</button>
+                    <label>
+                      Volume
+                      <input type="range" data-control="volume" min="0" max="1" step="0.05" value="1" />
+                    </label>
+                    <label>
+                      Speed
+                      <select data-control="speed">
+                        <option value="0.5">0.5x</option>
+                        <option value="0.75">0.75x</option>
+                        <option value="1" selected>1x</option>
+                        <option value="1.25">1.25x</option>
+                        <option value="1.5">1.5x</option>
+                        <option value="2">2x</option>
+                      </select>
+                    </label>
+                    <button type="button" data-control="fullscreen">Fullscreen</button>
+                    <button type="button" data-control="poster">Capture poster</button>
+                  </div>
+                </div>
+              </div>
+              <div class="video-pane__playlist" aria-label="Video playlist">
+                <h3>Playlist</h3>
+                <div id="playlist" class="playlist" role="list"></div>
+              </div>
+              <button class="metadata-toggle" type="button" data-action="metadata">Metadata drawer</button>
+            </section>
 
-          <section class="params-pane" aria-labelledby="params-title">
-            <div class="pane-header">
-              <h2 id="params-title">Parameters</h2>
-              <button class="pane-edit-btn" data-pane="parameters" type="button">Edit</button>
-            </div>
-            <dl id="params-list" class="definition-list"></dl>
-          </section>
+            <section class="params-pane" aria-labelledby="params-title">
+              <div class="pane-header">
+                <h2 id="params-title">Parameters</h2>
+                <button class="pane-edit-btn" data-pane="parameters" type="button">Edit</button>
+              </div>
+              <dl id="params-list" class="definition-list"></dl>
+            </section>
 
-          <section class="process-pane" aria-labelledby="process-title">
-            <div class="pane-header">
-              <h2 id="process-title">Process Flow</h2>
-              <button class="pane-edit-btn" data-pane="process" type="button">Edit</button>
-            </div>
-            <div id="process-flow" class="process-flow" tabindex="0">
-              <svg id="process-svg" class="process-flow__svg" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Process flow diagram"></svg>
-              <div id="process-nodes" class="process-flow__nodes" role="list"></div>
-            </div>
-          </section>
+            <section class="process-pane" aria-labelledby="process-title">
+              <div class="pane-header">
+                <h2 id="process-title">Process Flow</h2>
+                <button class="pane-edit-btn" data-pane="process" type="button">Edit</button>
+              </div>
+              <div id="process-flow" class="process-flow" tabindex="0">
+                <svg
+                  id="process-svg"
+                  class="process-flow__svg"
+                  xmlns="http://www.w3.org/2000/svg"
+                  role="img"
+                  aria-label="Process flow diagram"
+                ></svg>
+                <div id="process-nodes" class="process-flow__nodes" role="list"></div>
+              </div>
+            </section>
 
-          <section class="modules-pane" aria-labelledby="modules-title">
-            <div class="pane-header">
-              <h2 id="modules-title">Modules</h2>
-              <button class="pane-edit-btn" data-pane="modules" type="button">Edit</button>
-            </div>
-            <ul id="modules-list" class="module-list"></ul>
-          </section>
-        </main>
+            <section class="modules-pane" aria-labelledby="modules-title">
+              <div class="pane-header">
+                <h2 id="modules-title">Modules</h2>
+                <button class="pane-edit-btn" data-pane="modules" type="button">Edit</button>
+              </div>
+              <ul id="modules-list" class="module-list"></ul>
+            </section>
+          </main>
+        </div>
+
+        <div
+          id="metadata-drawer"
+          class="metadata-drawer"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="metadata-title"
+          hidden
+        >
+          <div class="metadata-drawer__header">
+            <h2 id="metadata-title">Metadata overview</h2>
+            <button type="button" data-action="close-metadata" aria-label="Close metadata">✕</button>
+          </div>
+          <div class="metadata-drawer__content">
+            <section>
+              <h3>Parameters</h3>
+              <dl id="drawer-params" class="definition-list"></dl>
+            </section>
+            <section>
+              <h3>Process</h3>
+              <ol id="drawer-process" class="drawer-process"></ol>
+            </section>
+            <section>
+              <h3>Modules</h3>
+              <ul id="drawer-modules" class="module-list"></ul>
+            </section>
+            <section>
+              <h3>Notes</h3>
+              <textarea id="drawer-notes" rows="6" placeholder="Add operational notes"></textarea>
+              <button type="button" data-action="save-notes" class="pill-btn">Save notes</button>
+            </section>
+          </div>
+        </div>
       </div>
 
-      <div id="metadata-drawer" class="metadata-drawer" role="dialog" aria-modal="true" aria-labelledby="metadata-title" hidden>
-        <div class="metadata-drawer__header">
-          <h2 id="metadata-title">Metadata overview</h2>
-          <button type="button" data-action="close-metadata" aria-label="Close metadata">✕</button>
-        </div>
-        <div class="metadata-drawer__content">
-          <section>
-            <h3>Parameters</h3>
-            <dl id="drawer-params" class="definition-list"></dl>
+      <div class="view view--dashboard" data-view="dashboard" hidden>
+        <div class="dashboard-view" aria-live="polite">
+          <section class="dashboard-filters" aria-labelledby="dashboard-filters-title">
+            <div class="section-header">
+              <h2 id="dashboard-filters-title">筛选条件</h2>
+              <p>组合过滤器快速定位目标生产视频</p>
+            </div>
+            <div class="filter-grid">
+              <label>
+                <span>型号系列</span>
+                <select data-filter="modelSeries"></select>
+              </label>
+              <label>
+                <span>灌装重量</span>
+                <select data-filter="fillWeight"></select>
+              </label>
+              <label>
+                <span>压盖方式</span>
+                <select data-filter="capping"></select>
+              </label>
+              <label>
+                <span>输送方式</span>
+                <select data-filter="conveying"></select>
+              </label>
+              <label>
+                <span>缓存方式</span>
+                <select data-filter="buffering"></select>
+              </label>
+              <label>
+                <span>VOC要求</span>
+                <select data-filter="voc"></select>
+              </label>
+              <label>
+                <span>防爆要求</span>
+                <select data-filter="explosion"></select>
+              </label>
+            </div>
           </section>
-          <section>
-            <h3>Process</h3>
-            <ol id="drawer-process" class="drawer-process"></ol>
+
+          <section class="dashboard-insights" aria-labelledby="dashboard-insights-title">
+            <div class="section-header">
+              <h2 id="dashboard-insights-title">产线洞察</h2>
+              <p>按过滤结果实时刷新</p>
+            </div>
+            <div class="dashboard-insights__grid">
+              <div class="chart-card">
+                <h3>灌装重量分布</h3>
+                <canvas id="dashboard-chart" aria-label="灌装重量分布图" role="img"></canvas>
+              </div>
+              <div class="chart-card">
+                <h3>绩效指标雷达图</h3>
+                <canvas id="dashboard-radar" aria-label="绩效指标雷达图" role="img"></canvas>
+              </div>
+            </div>
           </section>
-          <section>
-            <h3>Modules</h3>
-            <ul id="drawer-modules" class="module-list"></ul>
+
+          <section class="dashboard-results" aria-labelledby="dashboard-results-title">
+            <div class="section-header">
+              <h2 id="dashboard-results-title">匹配视频</h2>
+              <p>点击条目更新预览</p>
+            </div>
+            <ul id="dashboard-results" class="dashboard-results__list" role="list"></ul>
           </section>
-          <section>
-            <h3>Notes</h3>
-            <textarea id="drawer-notes" rows="6" placeholder="Add operational notes"></textarea>
-            <button type="button" data-action="save-notes" class="pill-btn">Save notes</button>
+
+          <section class="dashboard-preview" aria-labelledby="dashboard-preview-title">
+            <div class="section-header">
+              <h2 id="dashboard-preview-title">视频预览</h2>
+              <p>展示过滤结果中的代表片段</p>
+            </div>
+            <div class="dashboard-preview__player">
+              <video id="dashboard-preview-video" controls playsinline></video>
+            </div>
+            <div class="dashboard-preview__meta">
+              <h3 id="dashboard-preview-name"></h3>
+              <p id="dashboard-preview-meta"></p>
+            </div>
           </section>
         </div>
       </div>
 
       <div id="toast-region" class="toast-region" role="status" aria-live="polite"></div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -173,6 +173,39 @@ button {
   gap: 2rem;
 }
 
+.view {
+  display: none;
+}
+
+.view.is-active {
+  display: block;
+}
+
+.primary-nav {
+  display: flex;
+  gap: 1rem;
+  padding: 1.5rem 2.5rem 0;
+}
+
+.primary-nav__btn {
+  border: none;
+  background: rgba(15, 23, 42, 0.05);
+  color: var(--text-subtle);
+  padding: 0.6rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 500;
+  transition: background var(--transition), color var(--transition), box-shadow var(--transition);
+}
+
+.primary-nav__btn.is-active,
+.primary-nav__btn:hover,
+.primary-nav__btn:focus-visible {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.2);
+  outline: none;
+}
+
 .sidebar {
   display: flex;
   flex-direction: column;
@@ -511,6 +544,161 @@ button {
   background: rgba(37, 99, 235, 0.2);
   transform: translateY(-1px);
   outline: none;
+}
+
+.dashboard-view {
+  display: grid;
+  gap: 2rem;
+  padding: 2.5rem;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.section-header p {
+  margin: 0;
+  color: var(--text-subtle);
+  font-size: 0.9rem;
+}
+
+.dashboard-filters,
+.dashboard-insights,
+.dashboard-results,
+.dashboard-preview {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 1.75rem;
+  box-shadow: var(--shadow);
+}
+
+.filter-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.filter-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+}
+
+.filter-grid select {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  padding: 0.5rem 1rem;
+  font-size: 0.95rem;
+  color: var(--text);
+  background: var(--surface-elevated);
+}
+
+.dashboard-insights__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.chart-card {
+  background: var(--surface-elevated);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
+}
+
+.chart-card h3 {
+  margin: 0 0 1rem;
+  font-size: 1rem;
+}
+
+.chart-card canvas {
+  width: 100% !important;
+  max-width: 100%;
+  height: 260px !important;
+}
+
+.dashboard-results__list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.dashboard-results__item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-elevated);
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.4rem;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.dashboard-results__item button {
+  display: contents;
+}
+
+.dashboard-results__item:hover,
+.dashboard-results__item:focus-within,
+.dashboard-results__item.is-active {
+  border-color: var(--accent);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.18);
+}
+
+.dashboard-results__title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.dashboard-results__meta {
+  margin: 0;
+  color: var(--text-subtle);
+  font-size: 0.85rem;
+}
+
+.dashboard-preview__player {
+  margin-top: 1.5rem;
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: #000;
+  aspect-ratio: 16 / 9;
+}
+
+.dashboard-preview__player video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.dashboard-preview__meta {
+  margin-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.dashboard-preview__meta h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.dashboard-preview__meta p {
+  margin: 0;
+  color: var(--text-subtle);
+  line-height: 1.4;
 }
 
 .pane-header {


### PR DESCRIPTION
## Summary
- introduce navigation to toggle between the existing video management tools and a new dashboard view
- build dashboard filters, results list, and video preview powered by a curated production video dataset
- load Chart.js from CDN and render bar and radar charts that refresh when filters change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e86b0a55b8833199d8790062cbd349