### PR TITLE
feat: add browser-based video manager and dashboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,688 @@
+const { openDB } = window.idb;
+
+const CATEGORY_OPTIONS = {
+  series: ['30A', '30B', '30BG-', '30G', '30GY', 'ZSQ', 'HX200', '2T'],
+  weight: ['0.5~5kg', '10~20kg', '50~200kg', '1000kg'],
+  capping: ['5L平板压盖', '20L平板压盖', '花篮压盖', '辊压', '助力臂拧盖', '无'],
+  conveyor: ['滚筒', '板链', '无'],
+  buffer: ['不锈钢面板', '无动力滚筒', '无动力滚筒延长架', '无'],
+  voc: ['一体式集气罩', '灌装阀集气罩', '无'],
+  explosion: ['防爆', '不防爆'],
+};
+
+class VideoStore {
+  static async create() {
+    const db = await openDB('hx-video-manager', 1, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains('videos')) {
+          const store = db.createObjectStore('videos', { keyPath: 'id' });
+          store.createIndex('createdAt', 'createdAt');
+        }
+      },
+    });
+    return new VideoStore(db);
+  }
+
+  constructor(db) {
+    this.db = db;
+  }
+
+  async getAll() {
+    return await this.db.getAllFromIndex('videos', 'createdAt');
+  }
+
+  async addFiles(files) {
+    const tx = this.db.transaction('videos', 'readwrite');
+    const store = tx.store;
+    const added = [];
+    for (const file of files) {
+      const id = crypto.randomUUID();
+      const record = {
+        id,
+        name: file.name,
+        clientName: '',
+        material: '',
+        series: CATEGORY_OPTIONS.series[0] ?? '',
+        weight: CATEGORY_OPTIONS.weight[0] ?? '',
+        capping: CATEGORY_OPTIONS.capping[0] ?? '',
+        conveyor: CATEGORY_OPTIONS.conveyor[0] ?? '',
+        buffer: CATEGORY_OPTIONS.buffer[0] ?? '',
+        voc: CATEGORY_OPTIONS.voc[0] ?? '',
+        explosion: CATEGORY_OPTIONS.explosion[0] ?? '',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        blob: file,
+        size: file.size,
+        type: file.type,
+        originalName: file.name,
+      };
+      await store.put(record);
+      added.push(record);
+    }
+    await tx.done;
+    return added;
+  }
+
+  async update(id, updates) {
+    const existing = await this.db.get('videos', id);
+    if (!existing) return null;
+    const updated = {
+      ...existing,
+      ...updates,
+      updatedAt: Date.now(),
+    };
+    await this.db.put('videos', updated);
+    return updated;
+  }
+
+  async deleteMany(ids) {
+    const tx = this.db.transaction('videos', 'readwrite');
+    for (const id of ids) {
+      await tx.store.delete(id);
+    }
+    await tx.done;
+  }
+
+  async deleteAll() {
+    await this.db.clear('videos');
+  }
+}
+
+const state = {
+  videos: [],
+  objectUrls: new Map(),
+  selected: new Set(),
+  editingIndex: null,
+  chart: null,
+  chartType: 'radar',
+};
+
+const elements = {
+  tabButtons: Array.from(document.querySelectorAll('.tab-button')),
+  sections: Array.from(document.querySelectorAll('.tab-section')),
+  uploadInput: document.getElementById('video-upload'),
+  tableBody: document.getElementById('video-table-body'),
+  selectAllBtn: document.getElementById('select-all'),
+  clearSelectionBtn: document.getElementById('clear-selection'),
+  deleteSelectedBtn: document.getElementById('delete-selected'),
+  deleteAllBtn: document.getElementById('delete-all'),
+  exportBtn: document.getElementById('export-csv'),
+  importInput: document.getElementById('import-csv'),
+  selectAllCheckbox: document.getElementById('select-all-checkbox'),
+  dashboardFilters: document.getElementById('dashboard-filters'),
+  viewToggleButtons: Array.from(document.querySelectorAll('.view-toggle button')),
+  chartCanvas: document.getElementById('distribution-chart'),
+  previewGrid: document.getElementById('preview-grid'),
+  editDialog: document.getElementById('edit-dialog'),
+  editForm: document.getElementById('edit-form'),
+  editPrev: document.getElementById('edit-prev'),
+  editNext: document.getElementById('edit-next'),
+  editCancel: document.getElementById('edit-cancel'),
+};
+
+function populateSelect(select, options, includeAll = false) {
+  select.innerHTML = '';
+  if (includeAll) {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = '全部';
+    select.append(option);
+  }
+  for (const value of options) {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = value;
+    select.append(option);
+  }
+}
+
+function initFilters() {
+  const filterForm = elements.dashboardFilters;
+  for (const [key, options] of Object.entries(CATEGORY_OPTIONS)) {
+    const select = filterForm.elements.namedItem(key);
+    if (select) {
+      populateSelect(select, options, true);
+    }
+  }
+
+  const editSelects = elements.editForm.querySelectorAll('select');
+  editSelects.forEach((select) => {
+    const key = select.name;
+    populateSelect(select, CATEGORY_OPTIONS[key] ?? []);
+  });
+}
+
+function switchTab(targetId) {
+  elements.tabButtons.forEach((btn) => {
+    const active = btn.dataset.target === targetId;
+    btn.classList.toggle('active', active);
+  });
+  elements.sections.forEach((section) => {
+    section.classList.toggle('active', section.id === targetId);
+  });
+}
+
+elements.tabButtons.forEach((btn) => {
+  btn.addEventListener('click', () => switchTab(btn.dataset.target));
+});
+
+function revokeObjectUrls() {
+  for (const url of state.objectUrls.values()) {
+    URL.revokeObjectURL(url);
+  }
+  state.objectUrls.clear();
+}
+
+function updateObjectUrl(video) {
+  if (state.objectUrls.has(video.id)) {
+    return state.objectUrls.get(video.id);
+  }
+  if (!video.blob) return '';
+  const url = URL.createObjectURL(video.blob);
+  state.objectUrls.set(video.id, url);
+  return url;
+}
+
+function formatSize(bytes) {
+  if (!bytes && bytes !== 0) return '';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let size = bytes;
+  let unit = units.shift();
+  while (size >= 1024 && units.length) {
+    size /= 1024;
+    unit = units.shift();
+  }
+  return `${size.toFixed(size >= 10 || !units.length ? 0 : 1)} ${unit}`;
+}
+
+function renderTable() {
+  const tbody = elements.tableBody;
+  tbody.innerHTML = '';
+  const fragment = document.createDocumentFragment();
+  for (const [index, video] of state.videos.entries()) {
+    const tr = document.createElement('tr');
+    const checkboxCell = document.createElement('td');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = state.selected.has(video.id);
+    checkbox.addEventListener('change', () => {
+      if (checkbox.checked) {
+        state.selected.add(video.id);
+      } else {
+        state.selected.delete(video.id);
+      }
+      refreshSelectionUI();
+    });
+    checkboxCell.append(checkbox);
+    tr.append(checkboxCell);
+
+    const previewCell = document.createElement('td');
+    const videoEl = document.createElement('video');
+    videoEl.className = 'video-preview';
+    videoEl.src = updateObjectUrl(video);
+    videoEl.controls = true;
+    videoEl.muted = true;
+    previewCell.append(videoEl);
+    tr.append(previewCell);
+
+    const cells = [
+      video.name,
+      video.clientName,
+      video.material,
+      video.series,
+      video.weight,
+      video.capping,
+      video.conveyor,
+      video.buffer,
+      video.voc,
+      video.explosion,
+    ];
+
+    for (const value of cells) {
+      const td = document.createElement('td');
+      td.textContent = value || '—';
+      tr.append(td);
+    }
+
+    const actionsCell = document.createElement('td');
+    const sizeInfo = document.createElement('div');
+    sizeInfo.className = 'meta';
+    sizeInfo.textContent = formatSize(video.size);
+    const editButton = document.createElement('button');
+    editButton.textContent = '修改';
+    editButton.addEventListener('click', () => openEditDialog(index));
+    actionsCell.append(editButton, sizeInfo);
+    tr.append(actionsCell);
+
+    fragment.append(tr);
+  }
+  tbody.append(fragment);
+  elements.selectAllCheckbox.checked =
+    state.videos.length > 0 && state.selected.size === state.videos.length;
+}
+
+function refreshSelectionUI() {
+  const hasSelection = state.selected.size > 0;
+  elements.clearSelectionBtn.disabled = !hasSelection;
+  elements.deleteSelectedBtn.disabled = !hasSelection;
+  elements.selectAllBtn.disabled = state.videos.length === 0;
+  elements.deleteAllBtn.disabled = state.videos.length === 0;
+  elements.exportBtn.disabled = state.videos.length === 0;
+  elements.selectAllCheckbox.indeterminate =
+    hasSelection && state.selected.size !== state.videos.length;
+  elements.selectAllCheckbox.checked =
+    state.videos.length > 0 && state.selected.size === state.videos.length;
+}
+
+function applyFilters() {
+  const formData = new FormData(elements.dashboardFilters);
+  const filters = Object.fromEntries(formData.entries());
+  return state.videos.filter((video) => {
+    return Object.entries(filters).every(([key, value]) => {
+      if (!value) return true;
+      return video[key] === value;
+    });
+  });
+}
+
+function updateChart() {
+  const filtered = applyFilters();
+  const categories = CATEGORY_OPTIONS.series;
+  const counts = categories.map(
+    (series) => filtered.filter((video) => video.series === series).length,
+  );
+  const config = {
+    type: state.chartType,
+    data: {
+      labels: categories,
+      datasets: [
+        {
+          label: '视频数量',
+          data: counts,
+          backgroundColor: state.chartType === 'bar' ? '#93c5fd' : 'rgba(37, 99, 235, 0.4)',
+          borderColor: '#2563eb',
+          borderWidth: 2,
+          pointBackgroundColor: '#2563eb',
+          pointRadius: 4,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      scales: state.chartType === 'bar'
+        ? {
+            y: {
+              beginAtZero: true,
+              ticks: {
+                precision: 0,
+              },
+            },
+          }
+        : {},
+      plugins: {
+        legend: {
+          display: false,
+        },
+      },
+    },
+  };
+
+  if (state.chart) {
+    state.chart.destroy();
+  }
+  state.chart = new Chart(elements.chartCanvas, config);
+}
+
+function renderPreviewGrid() {
+  const filtered = applyFilters();
+  elements.previewGrid.innerHTML = '';
+  if (filtered.length === 0) {
+    const empty = document.createElement('p');
+    empty.textContent = '暂无符合条件的视频，请调整筛选条件。';
+    empty.className = 'hint';
+    elements.previewGrid.append(empty);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  for (const video of filtered) {
+    const card = document.createElement('div');
+    card.className = 'preview-card';
+
+    const title = document.createElement('h3');
+    title.textContent = video.name;
+
+    const videoEl = document.createElement('video');
+    videoEl.controls = true;
+    videoEl.src = updateObjectUrl(video);
+    videoEl.setAttribute('preload', 'metadata');
+
+    const fullscreenBtn = document.createElement('button');
+    fullscreenBtn.className = 'fullscreen-btn';
+    fullscreenBtn.textContent = '全屏播放';
+    fullscreenBtn.addEventListener('click', () => {
+      if (videoEl.requestFullscreen) {
+        videoEl.requestFullscreen();
+      } else if (videoEl.webkitRequestFullscreen) {
+        videoEl.webkitRequestFullscreen();
+      }
+    });
+
+    const meta = document.createElement('div');
+    meta.className = 'meta';
+    meta.innerHTML = `
+      <span>客户：${video.clientName || '—'}</span>
+      <span>物料：${video.material || '—'}</span>
+      <span>型号系列：${video.series}</span>
+      <span>灌装重量：${video.weight}</span>
+      <span>压盖方式：${video.capping}</span>
+      <span>输送方式：${video.conveyor}</span>
+      <span>缓存方式：${video.buffer}</span>
+      <span>VOC 要求：${video.voc}</span>
+      <span>防爆要求：${video.explosion}</span>
+    `;
+
+    card.append(title, videoEl, fullscreenBtn, meta);
+    fragment.append(card);
+  }
+  elements.previewGrid.append(fragment);
+}
+
+function updateDashboard() {
+  updateChart();
+  renderPreviewGrid();
+}
+
+function openEditDialog(index) {
+  state.editingIndex = index;
+  const video = state.videos[index];
+  if (!video) return;
+  const form = elements.editForm;
+  form.elements.name.value = video.name;
+  form.elements.clientName.value = video.clientName || '';
+  form.elements.material.value = video.material || '';
+  for (const key of Object.keys(CATEGORY_OPTIONS)) {
+    if (form.elements[key]) {
+      form.elements[key].value = video[key] || '';
+    }
+  }
+  elements.editPrev.disabled = index === 0;
+  elements.editNext.disabled = index === state.videos.length - 1;
+  elements.editDialog.showModal();
+}
+
+function closeEditDialog() {
+  elements.editDialog.close();
+  state.editingIndex = null;
+}
+
+elements.editPrev.addEventListener('click', () => {
+  if (state.editingIndex === null) return;
+  const prevIndex = Math.max(0, state.editingIndex - 1);
+  openEditDialog(prevIndex);
+});
+
+elements.editNext.addEventListener('click', () => {
+  if (state.editingIndex === null) return;
+  const nextIndex = Math.min(state.videos.length - 1, state.editingIndex + 1);
+  openEditDialog(nextIndex);
+});
+
+elements.editCancel.addEventListener('click', () => {
+  closeEditDialog();
+});
+
+elements.editForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  if (state.editingIndex === null) return;
+  const video = state.videos[state.editingIndex];
+  const formData = new FormData(elements.editForm);
+  const updates = Object.fromEntries(formData.entries());
+  updates.name = updates.name.trim();
+  await store.update(video.id, updates);
+  await hydrateState();
+  closeEditDialog();
+});
+
+elements.editDialog.addEventListener('close', () => {
+  state.editingIndex = null;
+});
+
+function createCSVRow(values) {
+  return values
+    .map((value) => {
+      if (value == null) return '';
+      const text = String(value);
+      if (/[",\n]/.test(text)) {
+        return '"' + text.replace(/"/g, '""') + '"';
+      }
+      return text;
+    })
+    .join(',');
+}
+
+function exportCSV() {
+  const headers = [
+    'id',
+    '文件名',
+    '客户名称',
+    '物料信息',
+    '型号系列',
+    '灌装重量',
+    '压盖方式',
+    '输送方式',
+    '缓存方式',
+    'VOC要求',
+    '防爆要求',
+    '原始文件名',
+    '文件大小',
+  ];
+  const rows = [createCSVRow(headers)];
+  for (const video of state.videos) {
+    rows.push(
+      createCSVRow([
+        video.id,
+        video.name,
+        video.clientName,
+        video.material,
+        video.series,
+        video.weight,
+        video.capping,
+        video.conveyor,
+        video.buffer,
+        video.voc,
+        video.explosion,
+        video.originalName,
+        video.size,
+      ]),
+    );
+  }
+  const blob = new Blob([rows.join('\n')], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  const timestamp = new Date().toISOString().split('T')[0];
+  link.href = url;
+  link.download = `视频信息_${timestamp}.csv`;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function parseCSV(text) {
+  const rows = [];
+  let current = '';
+  let inQuotes = false;
+  const pushValue = (row) => {
+    if (!rows[row]) rows[row] = [];
+    rows[row].push(current);
+    current = '';
+  };
+  let row = 0;
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (text[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ',') {
+        pushValue(row);
+      } else if (char === '\n') {
+        pushValue(row);
+        row += 1;
+      } else if (char === '\r') {
+        // ignore
+      } else {
+        current += char;
+      }
+    }
+  }
+  pushValue(row);
+  return rows.filter((r) => r.length > 0);
+}
+
+async function importCSV(file) {
+  if (!file) return;
+  const text = await file.text();
+  const rows = parseCSV(text);
+  if (rows.length <= 1) return;
+  const [header, ...dataRows] = rows;
+  const headerMap = header.map((h) => h.trim());
+  for (const row of dataRows) {
+    const entry = {};
+    headerMap.forEach((key, idx) => {
+      entry[key] = row[idx];
+    });
+    if (!entry.id) continue;
+    const updates = {
+      name: entry['文件名'],
+      clientName: entry['客户名称'],
+      material: entry['物料信息'],
+      series: entry['型号系列'],
+      weight: entry['灌装重量'],
+      capping: entry['压盖方式'],
+      conveyor: entry['输送方式'],
+      buffer: entry['缓存方式'],
+      voc: entry['VOC要求'],
+      explosion: entry['防爆要求'],
+    };
+    await store.update(entry.id, updates);
+  }
+  await hydrateState();
+}
+
+async function hydrateState() {
+  const videos = await store.getAll();
+  revokeObjectUrls();
+  videos.sort((a, b) => a.createdAt - b.createdAt);
+  state.videos = videos;
+  state.selected.clear();
+  renderTable();
+  refreshSelectionUI();
+  updateDashboard();
+}
+
+function setupSelectionControls() {
+  elements.selectAllBtn.addEventListener('click', () => {
+    state.selected = new Set(state.videos.map((video) => video.id));
+    renderTable();
+    refreshSelectionUI();
+  });
+
+  elements.clearSelectionBtn.addEventListener('click', () => {
+    state.selected.clear();
+    renderTable();
+    refreshSelectionUI();
+  });
+
+  elements.deleteSelectedBtn.addEventListener('click', async () => {
+    if (state.selected.size === 0) return;
+    if (!confirm(`确定删除选中的 ${state.selected.size} 个视频吗？`)) return;
+    await store.deleteMany(Array.from(state.selected));
+    await hydrateState();
+  });
+
+  elements.deleteAllBtn.addEventListener('click', async () => {
+    if (state.videos.length === 0) return;
+    if (!confirm('确定删除全部视频及其信息吗？此操作不可撤销。')) return;
+    await store.deleteAll();
+    await hydrateState();
+  });
+
+  elements.selectAllCheckbox.addEventListener('change', (event) => {
+    if (event.target.checked) {
+      state.selected = new Set(state.videos.map((video) => video.id));
+    } else {
+      state.selected.clear();
+    }
+    renderTable();
+    refreshSelectionUI();
+  });
+}
+
+function setupDashboardControls() {
+  elements.dashboardFilters.addEventListener('input', () => {
+    updateDashboard();
+  });
+
+  elements.dashboardFilters.addEventListener('reset', (event) => {
+    event.preventDefault();
+    for (const element of elements.dashboardFilters.elements) {
+      if (element.tagName === 'SELECT') {
+        element.value = '';
+      }
+    }
+    updateDashboard();
+  });
+
+  elements.viewToggleButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      state.chartType = button.dataset.chart;
+      elements.viewToggleButtons.forEach((btn) =>
+        btn.classList.toggle('active', btn === button),
+      );
+      updateDashboard();
+    });
+  });
+}
+
+function setupFileControls() {
+  elements.uploadInput.addEventListener('change', async (event) => {
+    const files = Array.from(event.target.files || []);
+    if (!files.length) return;
+    await store.addFiles(files);
+    elements.uploadInput.value = '';
+    await hydrateState();
+  });
+
+  elements.exportBtn.addEventListener('click', exportCSV);
+
+  elements.importInput.addEventListener('change', async (event) => {
+    const file = event.target.files?.[0];
+    await importCSV(file);
+    elements.importInput.value = '';
+  });
+}
+
+let store;
+
+async function bootstrap() {
+  initFilters();
+  setupSelectionControls();
+  setupDashboardControls();
+  setupFileControls();
+  store = await VideoStore.create();
+  await hydrateState();
+}
+
+document.addEventListener('DOMContentLoaded', bootstrap);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>辉鑫科技视频管理器</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/idb@7/build/umd.js" defer></script>
+    <script src="app.js" type="module" defer></script>
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>辉鑫科技视频管理器</h1>
+      <nav class="tab-nav">
+        <button class="tab-button active" data-target="management">视频管理</button>
+        <button class="tab-button" data-target="dashboard">仪表板</button>
+      </nav>
+    </header>
+
+    <main>
+      <section id="management" class="tab-section active">
+        <div class="panel">
+          <h2>批量上传视频</h2>
+          <p class="hint">
+            支持 1 ~ 300MB 以内的视频文件，上传数量不限。文件将被持久保存，下一次打开仍可使用。
+          </p>
+          <label class="upload-label">
+            <input id="video-upload" type="file" accept="video/*" multiple hidden />
+            <span class="upload-action">选择视频文件</span>
+          </label>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>视频列表</h2>
+            <div class="panel-actions">
+              <button id="select-all">全选</button>
+              <button id="clear-selection">取消选择</button>
+              <button id="delete-selected" class="danger">删除所选</button>
+              <button id="delete-all" class="danger">全部删除</button>
+              <button id="export-csv">导出 CSV</button>
+              <label class="import-label">
+                导入 CSV
+                <input id="import-csv" type="file" accept=".csv" hidden />
+              </label>
+            </div>
+          </div>
+
+          <div class="table-container">
+            <table>
+              <thead>
+                <tr>
+                  <th>
+                    <input type="checkbox" id="select-all-checkbox" />
+                  </th>
+                  <th>预览</th>
+                  <th>文件名</th>
+                  <th>客户名称</th>
+                  <th>物料信息</th>
+                  <th>型号系列</th>
+                  <th>灌装重量</th>
+                  <th>压盖方式</th>
+                  <th>输送方式</th>
+                  <th>缓存方式</th>
+                  <th>VOC 要求</th>
+                  <th>防爆要求</th>
+                  <th>操作</th>
+                </tr>
+              </thead>
+              <tbody id="video-table-body"></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section id="dashboard" class="tab-section">
+        <div class="panel">
+          <h2>筛选条件</h2>
+          <form id="dashboard-filters" class="filters">
+            <label>
+              型号系列
+              <select name="series"></select>
+            </label>
+            <label>
+              灌装重量
+              <select name="weight"></select>
+            </label>
+            <label>
+              压盖方式
+              <select name="capping"></select>
+            </label>
+            <label>
+              输送方式
+              <select name="conveyor"></select>
+            </label>
+            <label>
+              缓存方式
+              <select name="buffer"></select>
+            </label>
+            <label>
+              VOC 要求
+              <select name="voc"></select>
+            </label>
+            <label>
+              防爆要求
+              <select name="explosion"></select>
+            </label>
+            <button type="reset" class="secondary">重置筛选</button>
+          </form>
+        </div>
+
+        <div class="panel">
+          <div class="panel-header">
+            <h2>进度分布</h2>
+            <div class="view-toggle">
+              <button data-chart="radar" class="active">雷达图</button>
+              <button data-chart="bar">条形图</button>
+            </div>
+          </div>
+          <canvas id="distribution-chart" height="220"></canvas>
+        </div>
+
+        <div class="panel">
+          <h2>视频预览</h2>
+          <div id="preview-grid" class="preview-grid"></div>
+        </div>
+      </section>
+    </main>
+
+    <dialog id="edit-dialog">
+      <form method="dialog" id="edit-form">
+        <header class="dialog-header">
+          <button type="button" id="edit-prev" class="icon-button" aria-label="上一个">
+            ◀
+          </button>
+          <h3>修改视频信息</h3>
+          <button type="button" id="edit-next" class="icon-button" aria-label="下一个">
+            ▶
+          </button>
+        </header>
+
+        <div class="dialog-body">
+          <label>
+            文件名
+            <input type="text" name="name" required />
+          </label>
+          <label>
+            客户名称
+            <input type="text" name="clientName" />
+          </label>
+          <label>
+            物料信息
+            <input type="text" name="material" />
+          </label>
+          <label>
+            产品分类
+            <div class="dialog-grid">
+              <label>
+                型号系列
+                <select name="series"></select>
+              </label>
+              <label>
+                灌装重量
+                <select name="weight"></select>
+              </label>
+              <label>
+                压盖方式
+                <select name="capping"></select>
+              </label>
+              <label>
+                输送方式
+                <select name="conveyor"></select>
+              </label>
+              <label>
+                缓存方式
+                <select name="buffer"></select>
+              </label>
+              <label>
+                VOC 要求
+                <select name="voc"></select>
+              </label>
+              <label>
+                防爆要求
+                <select name="explosion"></select>
+              </label>
+            </div>
+          </label>
+        </div>
+
+        <footer class="dialog-footer">
+          <button type="button" id="edit-cancel" class="secondary">取消</button>
+          <button type="submit" class="primary">保存</button>
+        </footer>
+      </form>
+    </dialog>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,412 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg: #f5f7fb;
+  --panel: #ffffff;
+  --border: #d6d9e3;
+  --text: #1f2937;
+  --muted: #6b7280;
+  --accent: #2563eb;
+  --accent-strong: #1d4ed8;
+  --danger: #dc2626;
+  --danger-strong: #b91c1c;
+  --shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+h1,
+ h2,
+ h3,
+ h4,
+ h5,
+ h6 {
+  margin: 0;
+  font-weight: 600;
+}
+
+p {
+  margin: 0;
+}
+
+button,
+select,
+input {
+  font: inherit;
+}
+
+.app-header {
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  padding: 1.5rem clamp(1.5rem, 5vw, 3rem);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 2rem;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.tab-nav {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.tab-button {
+  border: 1px solid var(--border);
+  background: #f3f4f6;
+  color: var(--text);
+  padding: 0.5rem 1rem;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tab-button.active {
+  background: var(--accent);
+  color: white;
+  border-color: transparent;
+  box-shadow: 0 6px 12px rgba(37, 99, 235, 0.2);
+}
+
+main {
+  padding: clamp(1.5rem, 5vw, 3rem);
+  max-width: 1400px;
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+}
+
+.panel {
+  background: var(--panel);
+  border-radius: 1.25rem;
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.panel-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+button {
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+button:hover {
+  background: var(--accent-strong);
+}
+
+button:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.secondary {
+  background: #e5e7eb;
+  color: var(--text);
+}
+
+.secondary:hover {
+  background: #d1d5db;
+}
+
+.danger {
+  background: var(--danger);
+}
+
+.danger:hover {
+  background: var(--danger-strong);
+}
+
+.import-label,
+.upload-label {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: #f3f4f6;
+  color: var(--text);
+  cursor: pointer;
+  gap: 0.5rem;
+}
+
+.import-label input,
+.upload-label input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.upload-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.table-container {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: #f3f4f6;
+}
+
+td,
+th {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+
+tbody tr:hover {
+  background: #f9fafb;
+}
+
+.video-preview {
+  width: 140px;
+  height: 80px;
+  border-radius: 0.75rem;
+  background: #000;
+  object-fit: cover;
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  align-items: end;
+}
+
+.filters label {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.filters select {
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.5rem;
+  background: white;
+  color: var(--text);
+}
+
+.view-toggle {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.view-toggle button {
+  background: transparent;
+  color: var(--text);
+  border-radius: 0;
+  border: none;
+  padding: 0.4rem 1rem;
+}
+
+.view-toggle button.active {
+  background: var(--accent);
+  color: white;
+}
+
+.preview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.preview-card {
+  background: #f9fafb;
+  border-radius: 1rem;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid #e5e7eb;
+}
+
+.preview-card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.preview-card video {
+  width: 100%;
+  max-height: 160px;
+  border-radius: 0.75rem;
+  background: #000;
+}
+
+.preview-card .meta {
+  font-size: 0.85rem;
+  color: var(--muted);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.fullscreen-btn {
+  background: #10b981;
+}
+
+.fullscreen-btn:hover {
+  background: #059669;
+}
+
+.tab-section {
+  display: none;
+}
+
+.tab-section.active {
+  display: grid;
+  gap: 2rem;
+}
+
+#edit-dialog {
+  border: none;
+  border-radius: 1.5rem;
+  max-width: min(720px, 90vw);
+  padding: 0;
+  width: 100%;
+  box-shadow: var(--shadow);
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--accent);
+  color: #fff;
+  padding: 1rem 1.5rem;
+  border-radius: 1.5rem 1.5rem 0 0;
+}
+
+.dialog-body {
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.dialog-body label {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.dialog-body input,
+.dialog-body select {
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+}
+
+.dialog-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  padding: 1rem 1.5rem 1.5rem;
+}
+
+.icon-button {
+  background: rgba(255, 255, 255, 0.2);
+  color: inherit;
+  border-radius: 999px;
+  width: 2rem;
+  height: 2rem;
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+}
+
+.icon-button:hover {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+@media (max-width: 960px) {
+  .panel-actions {
+    justify-content: flex-start;
+  }
+
+  .video-preview {
+    width: 120px;
+    height: 70px;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-header {
+    justify-content: center;
+  }
+
+  .panel {
+    padding: 1.25rem;
+  }
+
+  .panel-actions {
+    gap: 0.5rem;
+  }
+
+  button,
+  .import-label,
+  .upload-label {
+    width: 100%;
+    justify-content: center;
+  }
+
+  table {
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
## Summary
- build a two-tab video manager with bulk upload, metadata editing, and CSV import/export
- persist video assets and metadata in IndexedDB for reliable reloads
- add a dashboard with filtering, Chart.js visualisations, and inline/fullscreen previews

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e87cd8bb1083318f3e501944c3f02f