### PR TITLE
Add persistent metadata dialog controls and dashboard layout updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,7 @@ const state = {
   chart: null,
   chartType: 'radar',
   editingIndex: null,
+  dialogMinimized: false,
   status: null,
   statusUpdatedAt: null,
 };
@@ -52,6 +53,10 @@ const elements = {
   editPrev: document.getElementById('edit-prev'),
   editNext: document.getElementById('edit-next'),
   editCancel: document.getElementById('edit-cancel'),
+  editMinimize: document.getElementById('edit-minimize'),
+  editClose: document.getElementById('edit-close'),
+  editSubtitle: document.getElementById('edit-dialog-subtitle'),
+  dialogHeader: document.querySelector('#edit-dialog .dialog-header'),
 };
 
 function formatBytes(size) {
@@ -96,6 +101,14 @@ function populateSelect(select, options, withBlank = true) {
   }
 }
 
+function ensureOption(key, value) {
+  const options = CATEGORY_OPTIONS[key] || [];
+  if (value && options.includes(value)) {
+    return value;
+  }
+  return options[0] || '';
+}
+
 function populateAllSelects() {
   const filterSelects = elements.dashboardFilters.querySelectorAll('select');
   filterSelects.forEach((select) => {
@@ -126,6 +139,10 @@ async function fetchStatus() {
 }
 
 async function fetchVideos() {
+  const currentEditingId =
+    elements.editDialog?.open && state.editingIndex != null
+      ? state.videos[state.editingIndex]?.id
+      : null;
   try {
     const response = await fetch(API_ENDPOINTS.videos);
     if (!response.ok) throw new Error('无法获取视频列表');
@@ -140,6 +157,15 @@ async function fetchVideos() {
   renderTable();
   refreshSelectionUI();
   updateDashboard();
+
+  if (currentEditingId && elements.editDialog?.open) {
+    const newIndex = state.videos.findIndex((video) => video.id === currentEditingId);
+    if (newIndex !== -1) {
+      setEditingIndex(newIndex);
+    } else {
+      elements.editDialog.close();
+    }
+  }
 }
 
 function videoUrl(video) {
@@ -247,6 +273,23 @@ function refreshSelectionUI() {
   if (elements.selectAllCheckbox) {
     elements.selectAllCheckbox.checked = total > 0 && selected === total;
     elements.selectAllCheckbox.indeterminate = selected > 0 && selected < total;
+  }
+}
+
+function updateEditDialogSummary() {
+  if (state.editingIndex == null) return;
+  const index = state.editingIndex;
+  const video = state.videos[index];
+  if (!video) return;
+  if (elements.editSubtitle) {
+    const title = video.name || video.storageName;
+    elements.editSubtitle.textContent = `第 ${index + 1} / ${state.videos.length} 个 · ${title}`;
+  }
+  if (elements.editPrev) {
+    elements.editPrev.disabled = index <= 0;
+  }
+  if (elements.editNext) {
+    elements.editNext.disabled = index >= state.videos.length - 1;
   }
 }
 
@@ -620,21 +663,11 @@ function setupTableListeners() {
 function openEditDialog(id) {
   const index = state.videos.findIndex((video) => video.id === id);
   if (index === -1) return;
-  state.editingIndex = index;
-  const video = state.videos[index];
-  const form = elements.editForm;
-  form.name.value = video.name || '';
-  form.clientName.value = video.clientName || '';
-  form.material.value = video.material || '';
-  form.series.value = video.series || CATEGORY_OPTIONS.series[0];
-  form.weight.value = video.weight || CATEGORY_OPTIONS.weight[0];
-  form.capping.value = video.capping || CATEGORY_OPTIONS.capping[0];
-  form.conveyor.value = video.conveyor || CATEGORY_OPTIONS.conveyor[0];
-  form.buffer.value = video.buffer || CATEGORY_OPTIONS.buffer[0];
-  form.voc.value = video.voc || CATEGORY_OPTIONS.voc[0];
-  form.explosion.value = video.explosion || CATEGORY_OPTIONS.explosion[0];
-  if (typeof elements.editDialog.showModal === 'function') {
-    elements.editDialog.showModal();
+  setDialogMinimized(false);
+  if (setEditingIndex(index) && typeof elements.editDialog.showModal === 'function') {
+    if (!elements.editDialog.open) {
+      elements.editDialog.showModal();
+    }
   }
 }
 
@@ -642,7 +675,7 @@ function changeEditingIndex(direction) {
   if (state.editingIndex == null) return;
   const nextIndex = state.editingIndex + direction;
   if (nextIndex < 0 || nextIndex >= state.videos.length) return;
-  openEditDialog(state.videos[nextIndex].id);
+  setEditingIndex(nextIndex);
 }
 
 function setupEditDialog() {
@@ -652,24 +685,110 @@ function setupEditDialog() {
     elements.editDialog.close();
   });
 
+  elements.editMinimize.addEventListener('click', () => {
+    setDialogMinimized(!state.dialogMinimized);
+  });
+
+  elements.editClose.addEventListener('click', () => {
+    elements.editDialog.close();
+  });
+
+  if (elements.dialogHeader) {
+    elements.dialogHeader.addEventListener('click', (event) => {
+      if (!state.dialogMinimized) return;
+      if (event.target.closest('.dialog-window-controls')) return;
+      setDialogMinimized(false);
+    });
+  }
+
+  elements.editDialog.addEventListener('close', () => {
+    state.editingIndex = null;
+    setDialogMinimized(false);
+    if (elements.editSubtitle) {
+      elements.editSubtitle.textContent = '请选择要编辑的视频';
+    }
+  });
+
   elements.editForm.addEventListener('submit', async (event) => {
     event.preventDefault();
-    const video = state.videos[state.editingIndex];
+    const index = state.editingIndex;
+    if (index == null) return;
+    const video = state.videos[index];
     if (!video) return;
     const formData = new FormData(elements.editForm);
     const updates = Object.fromEntries(formData.entries());
-    const response = await fetch(API_ENDPOINTS.video(video.id), {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(updates),
-    });
-    if (!response.ok) {
+    try {
+      const response = await fetch(API_ENDPOINTS.video(video.id), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates),
+      });
+      if (!response.ok) {
+        throw new Error('保存失败');
+      }
+      const data = await response.json();
+      const updatedVideo = data.video || { ...video, ...updates };
+      const stateIndex = state.videos.findIndex((item) => item.id === video.id);
+      if (stateIndex !== -1) {
+        state.videos[stateIndex] = {
+          ...state.videos[stateIndex],
+          ...updatedVideo,
+        };
+      }
+      renderTable();
+      refreshSelectionUI();
+      updateDashboard();
+      if (stateIndex !== -1 && elements.editDialog?.open) {
+        setEditingIndex(stateIndex);
+      }
+      fetchStatus();
+    } catch (error) {
+      console.error(error);
       alert('保存失败，请稍后重试');
-      return;
     }
-    elements.editDialog.close();
-    await fetchVideos();
   });
+}
+
+function setEditingIndex(index) {
+  if (index == null || index < 0 || index >= state.videos.length) {
+    return false;
+  }
+  state.editingIndex = index;
+  const video = state.videos[index];
+  if (!video) {
+    return false;
+  }
+  const form = elements.editForm;
+  form.name.value = video.name || '';
+  form.clientName.value = video.clientName || '';
+  form.material.value = video.material || '';
+  form.series.value = ensureOption('series', video.series);
+  form.weight.value = ensureOption('weight', video.weight);
+  form.capping.value = ensureOption('capping', video.capping);
+  form.conveyor.value = ensureOption('conveyor', video.conveyor);
+  form.buffer.value = ensureOption('buffer', video.buffer);
+  form.voc.value = ensureOption('voc', video.voc);
+  form.explosion.value = ensureOption('explosion', video.explosion);
+  updateEditDialogSummary();
+  return true;
+}
+
+function setDialogMinimized(minimized) {
+  state.dialogMinimized = minimized;
+  if (elements.editDialog) {
+    elements.editDialog.classList.toggle('minimized', minimized);
+  }
+  if (elements.editMinimize) {
+    elements.editMinimize.textContent = minimized ? '▢' : '▁';
+    elements.editMinimize.setAttribute(
+      'aria-label',
+      minimized ? '还原编辑窗口' : '最小化编辑窗口',
+    );
+    elements.editMinimize.setAttribute(
+      'title',
+      minimized ? '还原编辑窗口' : '最小化编辑窗口',
+    );
+  }
 }
 
 function setupViewToggle() {

--- a/index.html
+++ b/index.html
@@ -172,11 +172,32 @@
     <dialog id="edit-dialog">
       <form method="dialog" id="edit-form">
         <header class="dialog-header">
-          <button type="button" id="edit-prev" class="icon-button" aria-label="上一个">
+          <button
+            type="button"
+            id="edit-prev"
+            class="edge-button edge-button--left"
+            aria-label="上一个视频"
+          >
             ◀
           </button>
-          <h3>修改视频信息</h3>
-          <button type="button" id="edit-next" class="icon-button" aria-label="下一个">
+          <div class="dialog-header-main">
+            <h3 id="edit-dialog-title">修改视频信息</h3>
+            <p class="dialog-subtitle" id="edit-dialog-subtitle">请选择要编辑的视频</p>
+          </div>
+          <div class="dialog-window-controls">
+            <button type="button" id="edit-minimize" class="icon-button" aria-label="最小化">
+              ▁
+            </button>
+            <button type="button" id="edit-close" class="icon-button" aria-label="关闭">
+              ×
+            </button>
+          </div>
+          <button
+            type="button"
+            id="edit-next"
+            class="edge-button edge-button--right"
+            aria-label="下一个视频"
+          >
             ▶
           </button>
         </header>
@@ -230,7 +251,7 @@
         </div>
 
         <footer class="dialog-footer">
-          <button type="button" id="edit-cancel" class="secondary">取消</button>
+          <button type="button" id="edit-cancel" class="secondary">关闭</button>
           <button type="submit" class="primary">保存</button>
         </footer>
       </form>

--- a/styles.css
+++ b/styles.css
@@ -391,7 +391,7 @@ tbody tr:hover {
 
 .preview-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1.5rem;
 }
 
@@ -420,14 +420,87 @@ tbody tr:hover {
   box-shadow: 0 12px 18px rgba(15, 23, 42, 0.12);
 }
 
+
+dialog {
+  border: none;
+  padding: 0;
+  border-radius: 1.5rem;
+  max-width: 760px;
+  width: min(95vw, 760px);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+
+dialog[open] {
+  animation: dialog-pop 0.2s ease-out;
+}
+
+dialog::backdrop {
+  background: rgba(15, 23, 42, 0.45);
+}
+
 .dialog-header {
+  position: relative;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   background: var(--accent);
   color: #fff;
-  padding: 1rem 1.5rem;
+  padding: 1rem 3.75rem;
   border-radius: 1.5rem 1.5rem 0 0;
+  min-height: 4.5rem;
+}
+
+.dialog-header-main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.dialog-subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dialog-window-controls {
+  position: absolute;
+  top: 0.8rem;
+  right: 1rem;
+  display: flex;
+  gap: 0.4rem;
+}
+
+.edge-button {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+  font-size: 1.1rem;
+  display: grid;
+  place-items: center;
+}
+
+.edge-button:hover {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.edge-button:disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.edge-button--left {
+  left: 1rem;
+}
+
+.edge-button--right {
+  right: 1rem;
 }
 
 .dialog-body {
@@ -466,8 +539,8 @@ tbody tr:hover {
   background: rgba(255, 255, 255, 0.2);
   color: inherit;
   border-radius: 999px;
-  width: 2rem;
-  height: 2rem;
+  width: 2.2rem;
+  height: 2.2rem;
   display: grid;
   place-items: center;
   font-size: 1.1rem;
@@ -480,6 +553,62 @@ tbody tr:hover {
 .status-legend {
   color: var(--muted);
   font-size: 0.9rem;
+}
+
+dialog.minimized {
+  position: fixed;
+  inset: auto 2rem 2rem auto;
+  margin: 0;
+  width: 320px;
+  min-width: 280px;
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+dialog.minimized::backdrop {
+  background: transparent;
+}
+
+dialog.minimized .dialog-body,
+dialog.minimized .dialog-footer {
+  display: none;
+}
+
+dialog.minimized .dialog-header {
+  border-radius: 1.5rem;
+  cursor: pointer;
+  padding: 0.75rem 3.75rem;
+}
+
+dialog.minimized .dialog-subtitle {
+  display: none;
+}
+
+dialog.minimized .edge-button {
+  display: none;
+}
+
+@keyframes dialog-pop {
+  from {
+    transform: translateY(12px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 1200px) {
+  .preview-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .preview-grid {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- redesign the video信息编辑对话框，增加窗口控制、导航字幕并支持最小化
- 在保存元数据时保持对话框打开，同时刷新本地状态并维持批量编辑体验
- 调整仪表板预览网格为三列布局并新增对话框的弹窗/最小化样式以提升可用性

## Testing
- ⚠️ `npm install` *(失败：npm registry 403，环境限制)*

------
https://chatgpt.com/codex/tasks/task_e_68e9b7b49b3083319d7c3025b8ff846f