### PR TITLE
Enhance video metadata dialog interactions and styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,10 @@ const elements = {
   editPrev: document.getElementById('edit-prev'),
   editNext: document.getElementById('edit-next'),
   editCancel: document.getElementById('edit-cancel'),
+  editMinimize: document.getElementById('edit-minimize'),
+  editClose: document.getElementById('edit-close'),
+  editStatus: document.getElementById('edit-status'),
+  editSubtitle: document.getElementById('edit-subtitle'),
 };
 
 function formatBytes(size) {
@@ -94,6 +98,16 @@ function populateSelect(select, options, withBlank = true) {
     option.textContent = value;
     select.appendChild(option);
   }
+}
+
+function ensureSelectValue(select, value, fallback) {
+  if (!select) return;
+  const existing = Array.from(select.options || []);
+  if (value && !existing.some((option) => option.value === value)) {
+    const option = new Option(value, value, true, true);
+    select.appendChild(option);
+  }
+  select.value = value || fallback;
 }
 
 function populateAllSelects() {
@@ -180,6 +194,36 @@ function renderStatusCards(container, status) {
   }
 }
 
+function setDialogMinimized(minimized) {
+  if (!elements.editDialog) return;
+  elements.editDialog.classList.toggle('minimized', minimized);
+  if (elements.editMinimize) {
+    elements.editMinimize.textContent = minimized ? '▢' : '▁';
+    elements.editMinimize.setAttribute('aria-pressed', minimized ? 'true' : 'false');
+    elements.editMinimize.setAttribute('title', minimized ? '还原' : '最小化');
+    elements.editMinimize.setAttribute(
+      'aria-label',
+      minimized ? '还原编辑框' : '最小化编辑框',
+    );
+  }
+}
+
+function updateEditStatus(message, variant = 'info') {
+  if (!elements.editStatus) return;
+  elements.editStatus.textContent = message || '';
+  elements.editStatus.classList.remove('error', 'success', 'loading');
+  if (!message) {
+    return;
+  }
+  if (variant === 'error') {
+    elements.editStatus.classList.add('error');
+  } else if (variant === 'success') {
+    elements.editStatus.classList.add('success');
+  } else if (variant === 'loading') {
+    elements.editStatus.classList.add('loading');
+  }
+}
+
 function updateStatusUI() {
   const status = state.status;
   const isOnline = status && status.status === 'online';
@@ -206,6 +250,13 @@ function updateStatusUI() {
 
   renderStatusCards(elements.managementStatus, status);
   renderStatusCards(elements.dashboardStatusGrid, status);
+}
+
+function updateEditNavigationButtons() {
+  if (!elements.editPrev || !elements.editNext) return;
+  elements.editPrev.disabled = state.editingIndex <= 0;
+  elements.editNext.disabled =
+    state.editingIndex == null || state.editingIndex >= state.videos.length - 1;
 }
 
 function renderTable() {
@@ -618,6 +669,7 @@ function setupTableListeners() {
 }
 
 function openEditDialog(id) {
+  if (!elements.editDialog || !elements.editForm) return;
   const index = state.videos.findIndex((video) => video.id === id);
   if (index === -1) return;
   state.editingIndex = index;
@@ -626,13 +678,25 @@ function openEditDialog(id) {
   form.name.value = video.name || '';
   form.clientName.value = video.clientName || '';
   form.material.value = video.material || '';
-  form.series.value = video.series || CATEGORY_OPTIONS.series[0];
-  form.weight.value = video.weight || CATEGORY_OPTIONS.weight[0];
-  form.capping.value = video.capping || CATEGORY_OPTIONS.capping[0];
-  form.conveyor.value = video.conveyor || CATEGORY_OPTIONS.conveyor[0];
-  form.buffer.value = video.buffer || CATEGORY_OPTIONS.buffer[0];
-  form.voc.value = video.voc || CATEGORY_OPTIONS.voc[0];
-  form.explosion.value = video.explosion || CATEGORY_OPTIONS.explosion[0];
+  ensureSelectValue(form.series, video.series, CATEGORY_OPTIONS.series[0]);
+  ensureSelectValue(form.weight, video.weight, CATEGORY_OPTIONS.weight[0]);
+  ensureSelectValue(form.capping, video.capping, CATEGORY_OPTIONS.capping[0]);
+  ensureSelectValue(form.conveyor, video.conveyor, CATEGORY_OPTIONS.conveyor[0]);
+  ensureSelectValue(form.buffer, video.buffer, CATEGORY_OPTIONS.buffer[0]);
+  ensureSelectValue(form.voc, video.voc, CATEGORY_OPTIONS.voc[0]);
+  ensureSelectValue(form.explosion, video.explosion, CATEGORY_OPTIONS.explosion[0]);
+  if (elements.editSubtitle) {
+    elements.editSubtitle.textContent = video.name || video.storageName || '未命名视频';
+  }
+  updateEditStatus('');
+  setDialogMinimized(false);
+  elements.editDialog.dataset.videoId = video.id;
+  const submitButton = elements.editForm.querySelector('button[type="submit"]');
+  if (submitButton) {
+    submitButton.disabled = false;
+    submitButton.textContent = '保存';
+  }
+  updateEditNavigationButtons();
   if (typeof elements.editDialog.showModal === 'function') {
     elements.editDialog.showModal();
   }
@@ -646,11 +710,37 @@ function changeEditingIndex(direction) {
 }
 
 function setupEditDialog() {
-  elements.editPrev.addEventListener('click', () => changeEditingIndex(-1));
-  elements.editNext.addEventListener('click', () => changeEditingIndex(1));
-  elements.editCancel.addEventListener('click', () => {
-    elements.editDialog.close();
-  });
+  if (!elements.editForm || !elements.editDialog) return;
+  if (elements.editPrev) {
+    elements.editPrev.addEventListener('click', () => changeEditingIndex(-1));
+  }
+  if (elements.editNext) {
+    elements.editNext.addEventListener('click', () => changeEditingIndex(1));
+  }
+  if (elements.editCancel) {
+    elements.editCancel.addEventListener('click', () => {
+      elements.editDialog.close();
+    });
+  }
+  if (elements.editClose) {
+    elements.editClose.addEventListener('click', () => {
+      elements.editDialog.close();
+    });
+  }
+  if (elements.editMinimize) {
+    elements.editMinimize.addEventListener('click', () => {
+      const minimized = !elements.editDialog.classList.contains('minimized');
+      setDialogMinimized(minimized);
+    });
+  }
+
+  if (elements.editDialog) {
+    elements.editDialog.addEventListener('close', () => {
+      state.editingIndex = null;
+      setDialogMinimized(false);
+      updateEditStatus('');
+    });
+  }
 
   elements.editForm.addEventListener('submit', async (event) => {
     event.preventDefault();
@@ -658,17 +748,49 @@ function setupEditDialog() {
     if (!video) return;
     const formData = new FormData(elements.editForm);
     const updates = Object.fromEntries(formData.entries());
-    const response = await fetch(API_ENDPOINTS.video(video.id), {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(updates),
-    });
-    if (!response.ok) {
-      alert('保存失败，请稍后重试');
-      return;
+    const submitButton = elements.editForm.querySelector('button[type="submit"]');
+    if (submitButton) {
+      submitButton.disabled = true;
+      submitButton.textContent = '保存中...';
     }
-    elements.editDialog.close();
-    await fetchVideos();
+    updateEditStatus('保存中，请稍候...', 'loading');
+
+    try {
+      const response = await fetch(API_ENDPOINTS.video(video.id), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates),
+      });
+      if (!response.ok) {
+        throw new Error('保存失败');
+      }
+      const payload = await response.json().catch(() => ({ video: null }));
+      const updatedVideo = payload.video ? { ...video, ...payload.video } : { ...video, ...updates };
+      const index = state.videos.findIndex((item) => item.id === video.id);
+      if (index !== -1) {
+        state.videos[index] = {
+          ...state.videos[index],
+          ...updatedVideo,
+        };
+        if (elements.editSubtitle) {
+          const refreshed = state.videos[index];
+          elements.editSubtitle.textContent = refreshed.name || refreshed.storageName || '未命名视频';
+        }
+      }
+      renderTable();
+      refreshSelectionUI();
+      updateDashboard();
+      updateEditStatus('保存成功，信息已同步到服务器。', 'success');
+      updateEditNavigationButtons();
+    } catch (error) {
+      console.error(error);
+      updateEditStatus('保存失败，请稍后重试。', 'error');
+    } finally {
+      if (submitButton) {
+        submitButton.disabled = false;
+        submitButton.textContent = '保存';
+      }
+    }
   });
 }
 

--- a/index.html
+++ b/index.html
@@ -172,11 +172,32 @@
     <dialog id="edit-dialog">
       <form method="dialog" id="edit-form">
         <header class="dialog-header">
-          <button type="button" id="edit-prev" class="icon-button" aria-label="上一个">
+          <button
+            type="button"
+            id="edit-prev"
+            class="icon-button dialog-nav dialog-nav-left"
+            aria-label="上一个"
+          >
             ◀
           </button>
-          <h3>修改视频信息</h3>
-          <button type="button" id="edit-next" class="icon-button" aria-label="下一个">
+          <div class="dialog-title-group">
+            <h3>修改视频信息</h3>
+            <p class="dialog-subtitle" id="edit-subtitle"></p>
+          </div>
+          <div class="dialog-header-actions">
+            <button type="button" id="edit-minimize" class="icon-button" aria-label="最小化">
+              ▁
+            </button>
+            <button type="button" id="edit-close" class="icon-button" aria-label="关闭">
+              ✕
+            </button>
+          </div>
+          <button
+            type="button"
+            id="edit-next"
+            class="icon-button dialog-nav dialog-nav-right"
+            aria-label="下一个"
+          >
             ▶
           </button>
         </header>
@@ -227,10 +248,11 @@
               </label>
             </div>
           </label>
+          <p class="form-status" id="edit-status" role="status" aria-live="polite"></p>
         </div>
 
         <footer class="dialog-footer">
-          <button type="button" id="edit-cancel" class="secondary">取消</button>
+          <button type="button" id="edit-cancel" class="secondary">关闭</button>
           <button type="submit" class="primary">保存</button>
         </footer>
       </form>

--- a/styles.css
+++ b/styles.css
@@ -46,6 +46,12 @@ input {
   font: inherit;
 }
 
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none !important;
+}
+
 .app-header {
   background: var(--panel);
   box-shadow: var(--shadow);
@@ -420,14 +426,67 @@ tbody tr:hover {
   box-shadow: 0 12px 18px rgba(15, 23, 42, 0.12);
 }
 
+dialog {
+  border: none;
+  border-radius: 1.5rem;
+  padding: 0;
+  width: min(90vw, 760px);
+  max-width: 760px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+dialog::backdrop {
+  background: rgba(15, 23, 42, 0.35);
+}
+
 .dialog-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   background: var(--accent);
   color: #fff;
-  padding: 1rem 1.5rem;
+  padding: 1rem 3.5rem;
   border-radius: 1.5rem 1.5rem 0 0;
+  position: relative;
+}
+
+.dialog-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  align-items: center;
+  text-align: center;
+}
+
+.dialog-subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dialog-header-actions {
+  position: absolute;
+  top: 50%;
+  right: 1rem;
+  display: flex;
+  gap: 0.35rem;
+  transform: translateY(-50%);
+}
+
+.dialog-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.dialog-nav-left {
+  left: -1rem;
+}
+
+.dialog-nav-right {
+  right: -1rem;
 }
 
 .dialog-body {
@@ -462,6 +521,25 @@ tbody tr:hover {
   padding: 1rem 1.5rem 1.5rem;
 }
 
+.form-status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+  min-height: 1.2rem;
+}
+
+.form-status.success {
+  color: var(--success);
+}
+
+.form-status.error {
+  color: var(--danger);
+}
+
+.form-status.loading {
+  color: var(--accent-strong);
+}
+
 .icon-button {
   background: rgba(255, 255, 255, 0.2);
   color: inherit;
@@ -475,6 +553,20 @@ tbody tr:hover {
 
 .icon-button:hover {
   background: rgba(255, 255, 255, 0.35);
+}
+
+dialog.minimized {
+  width: auto;
+}
+
+dialog.minimized .dialog-body,
+dialog.minimized .dialog-footer {
+  display: none;
+}
+
+dialog.minimized .dialog-header {
+  border-radius: 1.5rem;
+  padding-right: 2.75rem;
 }
 
 .status-legend {
@@ -519,5 +611,17 @@ tbody tr:hover {
 
   table {
     font-size: 0.88rem;
+  }
+
+  .dialog-header {
+    padding: 1rem 2.5rem;
+  }
+
+  .dialog-nav-left {
+    left: 0.25rem;
+  }
+
+  .dialog-nav-right {
+    right: 0.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- add dedicated minimize/close controls to the metadata dialog, keep it open after saving, and surface inline status messaging
- maintain navigation button states while editing videos and update form selections safely for previously imported values
- refresh dialog styling to emphasize side navigation arrows and responsive behavior for the enterprise UI

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e9b7b49b3083319d7c3025b8ff846f