### PR TITLE
Add high-fidelity Huixin OS mini program prototype

### DIFF
--- a/huixin-os-prototype.html
+++ b/huixin-os-prototype.html
@@ -1,0 +1,445 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>辉鑫OS 小程序高保真原型</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIrKc5xRkc8V4gWIDh0W1DHKP1QFjKtYB6YhZ4B4rN3g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://at.alicdn.com/t/c/font_4614540_f24sn087j7p.js" defer></script>
+  <style>
+    body {
+      background: radial-gradient(circle at top left, #f1f5f9, #e2e8f0 45%, #cbd5f5);
+      min-height: 100vh;
+    }
+    .prototype-screen {
+      box-shadow: 0 25px 60px rgba(15, 23, 42, 0.15);
+      border: 1px solid rgba(226, 232, 240, 0.7);
+      background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+    }
+    .status-dot::before {
+      content: "";
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      border-radius: 9999px;
+      background: #22c55e;
+      margin-right: 6px;
+    }
+    .iconfont {
+      font-family: "iconfont" !important;
+      font-size: 1.1rem;
+      font-style: normal;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+  </style>
+</head>
+<body class="font-sans text-slate-800">
+  <header class="max-w-7xl mx-auto px-8 py-10">
+    <div class="flex items-center gap-4">
+      <span class="relative inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-gradient-to-br from-blue-500 via-sky-400 to-indigo-500 text-white text-3xl font-semibold shadow-lg">辉</span>
+      <div>
+        <h1 class="text-4xl font-bold tracking-tight">辉鑫OS 小程序 · 高保真原型</h1>
+        <p class="text-slate-600 mt-2">核心功能：灌装机报价单生成、销售日志日历、AI 销售总结。遵循小程序界面规范，确保开发可直接对接。</p>
+      </div>
+    </div>
+  </header>
+
+  <main class="max-w-[1320px] mx-auto px-6 pb-16">
+    <section class="grid grid-cols-3 gap-10">
+      <!-- Prototype 1: 智能概览主页 -->
+      <article class="prototype-screen rounded-[36px] p-6 flex flex-col gap-6">
+        <header class="flex items-center justify-between">
+          <div class="text-xs text-slate-400">09:41</div>
+          <div class="flex gap-1 text-slate-400 text-xs">
+            <i class="fa-solid fa-signal"></i>
+            <i class="fa-solid fa-wifi"></i>
+            <i class="fa-solid fa-battery-three-quarters"></i>
+          </div>
+        </header>
+        <div class="rounded-3xl bg-gradient-to-br from-blue-500 via-sky-400 to-cyan-400 p-5 text-white shadow-inner">
+          <div class="flex justify-between items-center">
+            <div>
+              <p class="text-sm text-white/80">欢迎回来</p>
+              <h2 class="text-2xl font-semibold tracking-tight">辉鑫智能运营</h2>
+            </div>
+            <span class="status-dot text-xs uppercase tracking-widest">Online</span>
+          </div>
+          <div class="mt-5 grid grid-cols-2 gap-3 text-sm">
+            <div class="bg-white/15 rounded-2xl p-3">
+              <p class="text-white/80">本月线索</p>
+              <p class="text-2xl font-semibold">56</p>
+              <p class="text-xs text-emerald-200 mt-1 flex items-center gap-1"><i class="fa-solid fa-arrow-trend-up"></i> +12%</p>
+            </div>
+            <div class="bg-white/15 rounded-2xl p-3">
+              <p class="text-white/80">合同金额</p>
+              <p class="text-2xl font-semibold">¥1.28M</p>
+              <p class="text-xs text-white/70 mt-1">待签约 4 单</p>
+            </div>
+          </div>
+        </div>
+        <div class="bg-white/70 backdrop-blur-xl rounded-3xl p-5 shadow-lg">
+          <h3 class="text-base font-semibold flex items-center gap-2"><i class="fa-solid fa-rocket text-sky-500"></i> 快捷入口</h3>
+          <div class="grid grid-cols-3 gap-4 mt-4 text-center text-xs">
+            <button class="flex flex-col items-center gap-2 p-3 rounded-2xl bg-slate-50 hover:bg-slate-100 shadow-sm transition">
+              <i class="fa-solid fa-file-invoice text-blue-500 text-lg"></i>
+              报价单
+            </button>
+            <button class="flex flex-col items-center gap-2 p-3 rounded-2xl bg-slate-50 hover:bg-slate-100 shadow-sm transition">
+              <i class="fa-solid fa-calendar-check text-emerald-500 text-lg"></i>
+              销售日历
+            </button>
+            <button class="flex flex-col items-center gap-2 p-3 rounded-2xl bg-slate-50 hover:bg-slate-100 shadow-sm transition">
+              <i class="fa-solid fa-robot text-indigo-500 text-lg"></i>
+              AI总结
+            </button>
+          </div>
+        </div>
+        <div class="flex-1 bg-slate-50 rounded-3xl p-5 border border-slate-200">
+          <h3 class="font-semibold text-base">今日待办</h3>
+          <ul class="mt-4 space-y-4 text-sm text-slate-600">
+            <li class="flex items-start gap-3">
+              <span class="inline-flex items-center justify-center w-9 h-9 rounded-2xl bg-sky-500/10 text-sky-600"><i class="fa-solid fa-phone"></i></span>
+              <div>
+                <p>回访中港灌装项目</p>
+                <p class="text-xs text-slate-400">客户：周工 · 截止 15:00</p>
+              </div>
+            </li>
+            <li class="flex items-start gap-3">
+              <span class="inline-flex items-center justify-center w-9 h-9 rounded-2xl bg-amber-500/10 text-amber-600"><i class="fa-solid fa-comments"></i></span>
+              <div>
+                <p>对接售后方案确认</p>
+                <p class="text-xs text-slate-400">跟进人：刘敏</p>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- Prototype 2: 报价单生成 -->
+      <article class="prototype-screen rounded-[36px] p-6 flex flex-col gap-6">
+        <header class="flex items-center justify-between">
+          <div class="text-xs text-slate-400">09:41</div>
+          <div class="flex gap-1 text-slate-400 text-xs">
+            <i class="fa-solid fa-signal"></i>
+            <i class="fa-solid fa-wifi"></i>
+            <i class="fa-solid fa-battery-three-quarters"></i>
+          </div>
+        </header>
+        <div class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold flex items-center gap-2"><i class="fa-solid fa-file-pen text-sky-500"></i> 灌装机报价单</h2>
+          <button class="px-4 py-2 bg-sky-500 text-white text-xs rounded-full shadow">保存草稿</button>
+        </div>
+        <div class="bg-slate-50 rounded-3xl p-4 border border-slate-200 space-y-4">
+          <div>
+            <label class="text-xs text-slate-500">客户名称</label>
+            <div class="mt-1 flex items-center gap-2 bg-white rounded-2xl px-3 py-2 shadow-sm border border-slate-200">
+              <i class="fa-solid fa-building text-slate-400"></i>
+              <input type="text" placeholder="请输入企业名称" class="w-full text-sm focus:outline-none" />
+              <button class="text-xs text-sky-500">历史</button>
+            </div>
+          </div>
+          <div class="grid grid-cols-2 gap-3">
+            <div>
+              <label class="text-xs text-slate-500">灌装产能</label>
+              <div class="mt-1 flex items-center gap-2 bg-white rounded-2xl px-3 py-2 shadow-sm border border-slate-200">
+                <span class="iconfont text-slate-400">&#xe621;</span>
+                <input type="number" placeholder="瓶/小时" class="w-full text-sm focus:outline-none" />
+              </div>
+            </div>
+            <div>
+              <label class="text-xs text-slate-500">瓶型规格</label>
+              <div class="mt-1 flex items-center gap-2 bg-white rounded-2xl px-3 py-2 shadow-sm border border-slate-200">
+                <i class="fa-solid fa-prescription-bottle text-slate-400"></i>
+                <select class="w-full text-sm focus:outline-none bg-transparent">
+                  <option>500ml PET</option>
+                  <option>330ml 玻璃</option>
+                  <option>750ml 高端玻璃</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div>
+            <label class="text-xs text-slate-500">配置需求</label>
+            <textarea rows="4" placeholder="请描述灌装线布局、灭菌、贴标等细节" class="mt-1 w-full bg-white rounded-2xl px-3 py-3 text-sm border border-slate-200 shadow-sm focus:outline-none"></textarea>
+          </div>
+          <div class="bg-white rounded-2xl p-3 border border-dashed border-sky-200 text-xs text-slate-500 flex items-center justify-between">
+            <span class="flex items-center gap-3"><i class="fa-solid fa-paperclip text-sky-500"></i> 上传工艺流程 & 图纸</span>
+            <button class="px-3 py-1 rounded-full bg-sky-50 text-sky-500">上传</button>
+          </div>
+        </div>
+        <div class="bg-gradient-to-r from-sky-500/10 via-indigo-500/10 to-purple-500/10 rounded-3xl p-4 space-y-3">
+          <div class="flex justify-between items-center text-sm">
+            <span class="text-slate-500">预估总价</span>
+            <span class="text-2xl font-semibold text-sky-600">¥ 486,000</span>
+          </div>
+          <div class="flex items-center justify-between text-xs text-slate-500">
+            <span>含安装调试 / 质保 2 年</span>
+            <button class="px-4 py-2 rounded-full bg-sky-500 text-white shadow">生成报价单</button>
+          </div>
+        </div>
+      </article>
+
+      <!-- Prototype 3: 报价单预览与分享 -->
+      <article class="prototype-screen rounded-[36px] p-6 flex flex-col gap-6">
+        <header class="flex items-center justify-between">
+          <div class="text-xs text-slate-400">09:41</div>
+          <div class="flex gap-1 text-slate-400 text-xs">
+            <i class="fa-solid fa-signal"></i>
+            <i class="fa-solid fa-wifi"></i>
+            <i class="fa-solid fa-battery-three-quarters"></i>
+          </div>
+        </header>
+        <div class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold flex items-center gap-2"><i class="fa-solid fa-clipboard-list text-indigo-500"></i> 报价单预览</h2>
+          <button class="px-4 py-2 bg-emerald-500 text-white text-xs rounded-full shadow">发送客户</button>
+        </div>
+        <div class="bg-white rounded-3xl border border-slate-200 p-5 space-y-4">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-xs text-slate-500">报价编号</p>
+              <p class="text-sm font-semibold">HX-QT-202405-018</p>
+            </div>
+            <span class="px-3 py-1 rounded-full bg-emerald-100 text-emerald-600 text-xs">待确认</span>
+          </div>
+          <div class="grid grid-cols-2 gap-4 text-sm text-slate-600">
+            <div>
+              <p class="text-xs text-slate-500">客户单位</p>
+              <p>苏州泽林饮品有限公司</p>
+            </div>
+            <div>
+              <p class="text-xs text-slate-500">交付周期</p>
+              <p>45 天（含调试）</p>
+            </div>
+          </div>
+          <div class="bg-slate-50 rounded-2xl p-4 border border-slate-200">
+            <div class="flex items-center justify-between text-xs text-slate-500">
+              <span>灌装机主机（12 头）</span>
+              <span>¥ 220,000</span>
+            </div>
+            <div class="flex items-center justify-between text-xs text-slate-500 mt-2">
+              <span>无菌隧道 & CIP 系统</span>
+              <span>¥ 158,000</span>
+            </div>
+            <div class="flex items-center justify-between text-xs text-slate-500 mt-2">
+              <span>贴标、打码整线</span>
+              <span>¥ 108,000</span>
+            </div>
+            <div class="border-t border-dashed border-slate-300 mt-4 pt-3 flex items-center justify-between text-sm font-semibold text-slate-700">
+              <span>合计</span>
+              <span>¥ 486,000</span>
+            </div>
+          </div>
+          <div class="flex items-center justify-between text-xs text-slate-500">
+            <span class="flex items-center gap-2"><i class="fa-solid fa-file-signature text-slate-400"></i> 电子签收</span>
+            <button class="px-3 py-1 bg-indigo-500 text-white rounded-full">生成PDF</button>
+          </div>
+        </div>
+        <div class="mt-auto bg-gradient-to-r from-indigo-500/10 via-blue-500/10 to-sky-500/10 rounded-3xl p-4 flex items-center justify-between text-sm text-slate-600">
+          <div class="flex items-center gap-3">
+            <span class="w-10 h-10 rounded-2xl bg-white flex items-center justify-center shadow"><i class="fa-solid fa-share-nodes text-sky-500"></i></span>
+            <div>
+              <p class="font-semibold">分享给客户</p>
+              <p class="text-xs">微信/钉钉一键发送，跟踪阅读状态</p>
+            </div>
+          </div>
+          <button class="px-4 py-2 rounded-full bg-white text-sky-500 shadow">复制链接</button>
+        </div>
+      </article>
+
+      <!-- Prototype 4: 销售日志日历 -->
+      <article class="prototype-screen rounded-[36px] p-6 flex flex-col gap-6">
+        <header class="flex items-center justify-between">
+          <div class="text-xs text-slate-400">09:41</div>
+          <div class="flex gap-1 text-slate-400 text-xs">
+            <i class="fa-solid fa-signal"></i>
+            <i class="fa-solid fa-wifi"></i>
+            <i class="fa-solid fa-battery-three-quarters"></i>
+          </div>
+        </header>
+        <div class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold flex items-center gap-2"><i class="fa-solid fa-calendar-days text-emerald-500"></i> 销售日志</h2>
+          <button class="px-4 py-2 bg-white text-slate-600 text-xs rounded-full border border-slate-200 shadow-sm flex items-center gap-2"><i class="fa-solid fa-plus"></i> 新日志</button>
+        </div>
+        <div class="bg-white rounded-3xl p-4 border border-slate-200">
+          <div class="flex items-center justify-between text-sm text-slate-500">
+            <button class="p-2"><i class="fa-solid fa-chevron-left"></i></button>
+            <span class="font-semibold text-slate-700">2024 年 6 月</span>
+            <button class="p-2"><i class="fa-solid fa-chevron-right"></i></button>
+          </div>
+          <div class="grid grid-cols-7 gap-2 text-center text-xs mt-3 text-slate-400">
+            <span>一</span><span>二</span><span>三</span><span>四</span><span>五</span><span>六</span><span>日</span>
+          </div>
+          <div class="grid grid-cols-7 gap-2 mt-3">
+            <span class="h-10 flex items-center justify-center text-xs text-slate-300">27</span>
+            <span class="h-10 flex items-center justify-center text-xs text-slate-300">28</span>
+            <span class="h-10 flex items-center justify-center text-xs text-slate-300">29</span>
+            <span class="h-10 flex items-center justify-center text-xs text-slate-300">30</span>
+            <span class="h-10 flex items-center justify-center text-xs text-slate-300">31</span>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent bg-sky-50 text-sky-600 font-semibold">
+              1
+              <span class="text-[9px] text-sky-400">签合同</span>
+            </button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">2</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">3</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent bg-emerald-50 text-emerald-600 font-semibold">
+              4
+              <span class="text-[9px] text-emerald-400">回访</span>
+            </button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">5</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">6</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">7</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">8</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent bg-amber-50 text-amber-600 font-semibold">
+              9
+              <span class="text-[9px] text-amber-400">AI 线索</span>
+            </button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">10</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">11</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">12</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">13</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">14</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">15</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">16</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">17</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">18</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">19</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">20</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">21</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">22</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">23</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">24</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">25</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">26</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">27</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">28</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">29</button>
+            <button class="h-10 flex flex-col items-center justify-center text-xs rounded-2xl border border-transparent hover:border-slate-200">30</button>
+          </div>
+        </div>
+        <div class="bg-slate-50 rounded-3xl p-5 border border-slate-200 flex-1 flex flex-col">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-xs text-slate-500">日志概览 · 6 月 4 日</p>
+              <p class="text-base font-semibold">客户回访：华味鲜灌装项目</p>
+            </div>
+            <button class="text-xs text-sky-500">查看详情</button>
+          </div>
+          <div class="mt-3 text-sm text-slate-600 space-y-2">
+            <p><i class="fa-solid fa-clock text-emerald-400 mr-2"></i> 09:30 现场勘查 · 确认定制需求</p>
+            <p><i class="fa-solid fa-user-group text-emerald-400 mr-2"></i> 参与：销售（陈蕾）、技术（梁工）</p>
+            <p><i class="fa-solid fa-list-check text-emerald-400 mr-2"></i> 下一步：6 月 6 日提交调研报告</p>
+          </div>
+        </div>
+      </article>
+
+      <!-- Prototype 5: 日志详情 & 时间轴 -->
+      <article class="prototype-screen rounded-[36px] p-6 flex flex-col gap-6">
+        <header class="flex items-center justify-between">
+          <div class="text-xs text-slate-400">09:41</div>
+          <div class="flex gap-1 text-slate-400 text-xs">
+            <i class="fa-solid fa-signal"></i>
+            <i class="fa-solid fa-wifi"></i>
+            <i class="fa-solid fa-battery-three-quarters"></i>
+          </div>
+        </header>
+        <div class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold flex items-center gap-2"><i class="fa-solid fa-timeline text-blue-500"></i> 日志详情</h2>
+          <button class="px-4 py-2 bg-white text-slate-600 text-xs rounded-full border border-slate-200 shadow-sm">导出</button>
+        </div>
+        <div class="bg-white rounded-3xl border border-slate-200 p-5 space-y-5 flex-1">
+          <div class="flex items-start gap-3">
+            <span class="w-10 h-10 rounded-2xl bg-sky-500/10 text-sky-600 flex items-center justify-center"><i class="fa-solid fa-building"></i></span>
+            <div>
+              <p class="text-xs text-slate-500">客户</p>
+              <p class="text-base font-semibold">苏州泽林饮品有限公司</p>
+              <p class="text-xs text-slate-400 mt-1">联系人：周工 · 185****5920</p>
+            </div>
+          </div>
+          <div class="border-l-2 border-dashed border-slate-200 pl-4 space-y-4">
+            <div>
+              <p class="text-xs text-slate-500">09:00</p>
+              <p class="text-sm text-slate-600 mt-1">销售团队进场，讲解辉鑫OS 灌装智能模块及产能扩展方案。</p>
+            </div>
+            <div>
+              <p class="text-xs text-slate-500">10:20</p>
+              <p class="text-sm text-slate-600 mt-1">技术工程师进行产线测算，确认需要增加 2 套杀菌模块。</p>
+              <div class="mt-2 bg-sky-50 border border-sky-100 rounded-2xl p-3 text-xs text-sky-600 flex items-center gap-2"><i class="fa-solid fa-lightbulb"></i> AI 建议：推荐升级至自动视觉检测，提高验收效率 18%。</div>
+            </div>
+            <div>
+              <p class="text-xs text-slate-500">14:30</p>
+              <p class="text-sm text-slate-600 mt-1">确认预算范围 ¥50-60 万，要求 7 月底完成安装。</p>
+            </div>
+          </div>
+          <div class="mt-auto">
+            <label class="text-xs text-slate-500">备注补充</label>
+            <textarea rows="3" placeholder="输入后续跟进要点…" class="mt-1 w-full bg-slate-50 rounded-2xl px-3 py-3 text-sm border border-slate-200 focus:outline-none"></textarea>
+          </div>
+        </div>
+      </article>
+
+      <!-- Prototype 6: AI 销售总结 -->
+      <article class="prototype-screen rounded-[36px] p-6 flex flex-col gap-6">
+        <header class="flex items-center justify-between">
+          <div class="text-xs text-slate-400">09:41</div>
+          <div class="flex gap-1 text-slate-400 text-xs">
+            <i class="fa-solid fa-signal"></i>
+            <i class="fa-solid fa-wifi"></i>
+            <i class="fa-solid fa-battery-three-quarters"></i>
+          </div>
+        </header>
+        <div class="flex items-center justify-between">
+          <h2 class="text-lg font-semibold flex items-center gap-2"><i class="fa-solid fa-wand-magic-sparkles text-purple-500"></i> AI 销售总结</h2>
+          <button class="px-4 py-2 bg-purple-500 text-white text-xs rounded-full shadow">刷新总结</button>
+        </div>
+        <div class="bg-gradient-to-br from-purple-500 via-indigo-500 to-sky-500 text-white rounded-3xl p-5 shadow-lg">
+          <p class="text-xs text-white/80">统计周期</p>
+          <p class="text-xl font-semibold mt-1">2024.05.01 - 2024.05.31</p>
+          <div class="mt-4 grid grid-cols-3 gap-3 text-center text-xs">
+            <div class="bg-white/10 rounded-2xl p-3">
+              <p class="text-white/70">新增线索</p>
+              <p class="text-lg font-semibold">128</p>
+              <p class="text-emerald-200 mt-1 flex items-center justify-center gap-1"><i class="fa-solid fa-arrow-trend-up"></i> +18%</p>
+            </div>
+            <div class="bg-white/10 rounded-2xl p-3">
+              <p class="text-white/70">成交金额</p>
+              <p class="text-lg font-semibold">¥ 2.16M</p>
+              <p class="text-white/70 mt-1">超额 12%</p>
+            </div>
+            <div class="bg-white/10 rounded-2xl p-3">
+              <p class="text-white/70">平均周期</p>
+              <p class="text-lg font-semibold">18 天</p>
+              <p class="text-amber-200 mt-1 flex items-center justify-center gap-1"><i class="fa-solid fa-triangle-exclamation"></i> 延期 2 天</p>
+            </div>
+          </div>
+        </div>
+        <div class="bg-white rounded-3xl border border-slate-200 p-5 space-y-4 text-sm text-slate-600">
+          <div class="flex items-start gap-3">
+            <span class="w-10 h-10 rounded-2xl bg-purple-500/10 text-purple-500 flex items-center justify-center"><i class="fa-solid fa-chart-pie"></i></span>
+            <div>
+              <h3 class="text-base font-semibold text-slate-700">AI 重点洞察</h3>
+              <ul class="mt-2 space-y-2 text-xs text-slate-500">
+                <li class="flex items-start gap-2"><i class="fa-solid fa-circle text-purple-400 text-[6px] mt-1"></i> 食品饮料行业成交转化率 32%，较上月提升 6%。</li>
+                <li class="flex items-start gap-2"><i class="fa-solid fa-circle text-purple-400 text-[6px] mt-1"></i> 产能 8,000 瓶/小时以上客户平均报价 52.3 万。</li>
+                <li class="flex items-start gap-2"><i class="fa-solid fa-circle text-purple-400 text-[6px] mt-1"></i> 北方区域存在 4 个高潜商机，建议 6 月重点跟进。</li>
+              </ul>
+            </div>
+          </div>
+          <div class="bg-slate-50 border border-slate-200 rounded-2xl p-4">
+            <div class="flex items-center justify-between text-xs text-slate-500">
+              <span class="flex items-center gap-2"><i class="fa-solid fa-microphone-lines text-purple-400"></i> 汇报建议</span>
+              <button class="px-3 py-1 rounded-full bg-purple-500/10 text-purple-500">复制</button>
+            </div>
+            <p class="mt-3 text-sm text-slate-600 leading-relaxed">建议在月度汇报中强调：1）智能化产线方案带来的交付周期缩短；2）重点展示 3 个成功案例提升品牌力；3）提出 AI 预测的北区重点客户名单并安排联合拜访。</p>
+          </div>
+        </div>
+        <div class="mt-auto flex items-center justify-between text-xs text-slate-500">
+          <span class="flex items-center gap-2"><i class="fa-solid fa-bell text-slate-400"></i> 每周一 09:00 自动推送</span>
+          <button class="px-4 py-2 rounded-full bg-slate-900 text-white shadow">订阅报告</button>
+        </div>
+      </article>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a high-fidelity Huixin OS mini program prototype page with six key interface screens
- integrate Tailwind CSS, FontAwesome, and iconfont assets to mirror production-ready styling
- showcase quotation workflow, sales calendar logs, and AI summary capabilities for development handoff

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f438ca97ec83319be49e41db7b688b