### PR TITLE
Add interactive 3D Mars simulator

### DIFF
--- a/mars-simulator.html
+++ b/mars-simulator.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>3D 火星交互模拟器</title>
+    <link rel="stylesheet" href="mars.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="app-shell">
+      <aside class="control-panel">
+        <header class="panel-header">
+          <h1>火星地理标注控制台</h1>
+          <p>
+            在 3D 火星球体上点击或输入经纬度，创建自定义地名。点击地名或标记即可打开卡片，上传图片 / 视频并记录备注。
+          </p>
+        </header>
+
+        <section class="panel-section">
+          <h2>定位信息</h2>
+          <div class="field-grid">
+            <label>
+              地名
+              <input type="text" id="place-name" placeholder="如：奥林匹斯山" />
+            </label>
+            <label>
+              纬度
+              <input
+                type="number"
+                id="latitude"
+                min="-90"
+                max="90"
+                step="0.01"
+                placeholder="-90 ~ 90"
+              />
+            </label>
+            <label>
+              经度
+              <input
+                type="number"
+                id="longitude"
+                min="-180"
+                max="180"
+                step="0.01"
+                placeholder="-180 ~ 180"
+              />
+            </label>
+          </div>
+          <div class="button-row">
+            <button id="create-marker" class="primary">创建地名</button>
+            <button id="clear-selection" class="ghost">清空输入</button>
+          </div>
+          <p class="hint">点击火星表面时会自动更新经纬度。</p>
+        </section>
+
+        <section class="panel-section">
+          <h2>已创建地名</h2>
+          <ul id="place-list" class="place-list"></ul>
+          <p class="hint small">地名信息保存在浏览器内存中，刷新页面后将重置。</p>
+        </section>
+      </aside>
+
+      <main class="viewport">
+        <div id="scene-container" class="scene-container"></div>
+        <div class="status-bar">
+          <span>单击火星选择位置 · 双指/鼠标滚轮缩放 · 拖拽旋转视角</span>
+          <span id="status-message"></span>
+        </div>
+      </main>
+    </div>
+
+    <div id="card-layer" class="card-layer"></div>
+
+    <script type="module" src="mars.js"></script>
+  </body>
+</html>

--- a/mars.css
+++ b/mars.css
@@ -1,0 +1,388 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Space Grotesk', 'Segoe UI', sans-serif;
+  --panel-bg: rgba(18, 22, 28, 0.85);
+  --panel-border: rgba(255, 255, 255, 0.08);
+  --accent: #ff6f3c;
+  --accent-soft: rgba(255, 111, 60, 0.15);
+  --text-primary: #f1f5f9;
+  --text-secondary: #94a3b8;
+  --bg-gradient: radial-gradient(circle at top left, #1f2937, #020617 60%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+  background: #000;
+  color: var(--text-primary);
+}
+
+body {
+  background-image: var(--bg-gradient);
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: minmax(340px, 420px) minmax(0, 1fr);
+  width: min(1200px, 100%);
+  height: 100vh;
+}
+
+.control-panel {
+  backdrop-filter: blur(20px);
+  background: var(--panel-bg);
+  border-right: 1px solid var(--panel-border);
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.control-panel h1 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.control-panel h2 {
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+}
+
+.panel-header p {
+  color: var(--text-secondary);
+  margin: 12px 0 0;
+  line-height: 1.5;
+}
+
+.panel-section {
+  margin-top: 28px;
+  padding: 20px;
+  border: 1px solid var(--panel-border);
+  border-radius: 18px;
+  background: rgba(15, 18, 24, 0.9);
+  box-shadow: 0 20px 45px rgba(2, 6, 23, 0.35);
+}
+
+.field-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.field-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.field-grid input {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.8);
+  color: var(--text-primary);
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field-grid input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.button-row {
+  display: flex;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+button {
+  font-family: inherit;
+  font-size: 0.95rem;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+button.primary {
+  background: var(--accent);
+  color: #0f172a;
+  font-weight: 600;
+  box-shadow: 0 15px 30px rgba(255, 111, 60, 0.35);
+}
+
+button.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px rgba(255, 111, 60, 0.45);
+}
+
+button.ghost {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.3);
+  color: var(--text-secondary);
+}
+
+button.ghost:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.hint {
+  margin-top: 16px;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.6;
+}
+
+.hint.small {
+  margin-top: 12px;
+  font-size: 0.75rem;
+}
+
+.place-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
+.place-list li {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 14px;
+  padding: 12px 14px;
+  background: rgba(15, 23, 42, 0.65);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.place-list .name-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.name-row strong {
+  font-size: 1rem;
+}
+
+.name-row span.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 10px rgba(255, 111, 60, 0.7);
+}
+
+.place-meta {
+  display: flex;
+  gap: 12px;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  flex-wrap: wrap;
+}
+
+.place-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.place-actions button {
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  border-radius: 10px;
+}
+
+.place-actions button.secondary {
+  background: rgba(30, 41, 59, 0.8);
+  color: var(--text-primary);
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+.place-actions button.secondary:hover {
+  border-color: var(--accent);
+}
+
+.viewport {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.scene-container {
+  flex: 1;
+  position: relative;
+}
+
+.scene-container canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  border-radius: 0 0 0 36px;
+}
+
+.status-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 20px;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  border-top: 1px solid rgba(148, 163, 184, 0.1);
+  background: rgba(15, 18, 24, 0.82);
+  backdrop-filter: blur(18px);
+}
+
+.card-layer {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+}
+
+.place-card {
+  position: absolute;
+  min-width: 280px;
+  max-width: 320px;
+  background: rgba(13, 16, 23, 0.95);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 18px 20px;
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.45);
+  pointer-events: auto;
+  animation: fadeIn 0.25s ease;
+}
+
+.place-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.place-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.place-card button.close {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.2rem;
+  padding: 4px;
+}
+
+.place-card button.close:hover {
+  color: var(--text-primary);
+}
+
+.card-field {
+  margin-bottom: 14px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.upload-area {
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: 14px;
+  padding: 12px;
+  text-align: center;
+  cursor: pointer;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.upload-area:hover {
+  border-color: var(--accent);
+  background: rgba(255, 111, 60, 0.05);
+}
+
+.upload-area input {
+  display: none;
+}
+
+.preview-area {
+  margin-top: 12px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: none;
+}
+
+.preview-area img,
+.preview-area video {
+  width: 100%;
+  display: block;
+}
+
+.place-card textarea {
+  margin-top: 12px;
+  width: 100%;
+  min-height: 90px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.8);
+  color: var(--text-primary);
+  padding: 12px;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.place-card textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1024px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+  }
+
+  .control-panel {
+    height: 50vh;
+  }
+}
+
+@media (max-width: 720px) {
+  .control-panel {
+    padding: 18px;
+  }
+
+  .panel-section {
+    padding: 16px;
+  }
+
+  .button-row {
+    flex-direction: column;
+  }
+
+  button {
+    width: 100%;
+  }
+}

--- a/mars.js
+++ b/mars.js
@@ -1,0 +1,411 @@
+import * as THREE from 'https://cdn.skypack.dev/three@0.158.0';
+import { OrbitControls } from 'https://cdn.skypack.dev/three@0.158.0/examples/jsm/controls/OrbitControls.js';
+
+const sceneContainer = document.getElementById('scene-container');
+const statusMessage = document.getElementById('status-message');
+const cardLayer = document.getElementById('card-layer');
+
+const nameInput = document.getElementById('place-name');
+const latInput = document.getElementById('latitude');
+const lonInput = document.getElementById('longitude');
+const createButton = document.getElementById('create-marker');
+const clearButton = document.getElementById('clear-selection');
+const placeList = document.getElementById('place-list');
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setPixelRatio(window.devicePixelRatio);
+sceneContainer.appendChild(renderer.domElement);
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color('#030712');
+
+const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100);
+camera.position.set(0, 0, 4.2);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.enableDamping = true;
+controls.dampingFactor = 0.05;
+controls.minDistance = 2.2;
+controls.maxDistance = 8;
+
+const ambientLight = new THREE.AmbientLight('#d1d5db', 0.6);
+scene.add(ambientLight);
+
+const directionalLight = new THREE.DirectionalLight('#fef3c7', 1.4);
+directionalLight.position.set(5, 3, 5);
+scene.add(directionalLight);
+
+const marsRadius = 1.6;
+const marsGeometry = new THREE.SphereGeometry(marsRadius, 128, 128);
+const textureLoader = new THREE.TextureLoader();
+const marsTexture = textureLoader.load(
+  'https://cdn.jsdelivr.net/gh/ajdruff/planet-textures@master/2k_mars.jpg'
+);
+const marsBump = textureLoader.load(
+  'https://cdn.jsdelivr.net/gh/ajdruff/planet-textures@master/2k_mars_bump.jpg'
+);
+const marsMaterial = new THREE.MeshPhongMaterial({
+  map: marsTexture,
+  bumpMap: marsBump,
+  bumpScale: 0.04,
+  shininess: 6,
+});
+const marsMesh = new THREE.Mesh(marsGeometry, marsMaterial);
+scene.add(marsMesh);
+
+const starsGeometry = new THREE.SphereGeometry(50, 64, 64);
+const starsMaterial = new THREE.MeshBasicMaterial({
+  map: textureLoader.load('https://cdn.jsdelivr.net/gh/mrdoob/three.js@r158/examples/textures/space/galaxy_starfield.png'),
+  side: THREE.BackSide,
+});
+const starfield = new THREE.Mesh(starsGeometry, starsMaterial);
+scene.add(starfield);
+
+const markerGroup = new THREE.Group();
+scene.add(markerGroup);
+
+let lastHitPoint = null;
+let selectedMarker = null;
+let markerSequence = 0;
+const markers = new Map();
+
+const raycaster = new THREE.Raycaster();
+const pointer = new THREE.Vector2();
+
+function resizeRenderer() {
+  const { clientWidth, clientHeight } = sceneContainer;
+  renderer.setSize(clientWidth, clientHeight, false);
+  camera.aspect = clientWidth / clientHeight;
+  camera.updateProjectionMatrix();
+}
+
+function onWindowResize() {
+  resizeRenderer();
+}
+
+resizeRenderer();
+window.addEventListener('resize', onWindowResize);
+
+function toLatLon(point) {
+  const normalized = point.clone().normalize();
+  const lat = THREE.MathUtils.radToDeg(Math.asin(normalized.y));
+  const lon = THREE.MathUtils.radToDeg(Math.atan2(normalized.x, normalized.z));
+  return { lat, lon };
+}
+
+function fromLatLon(lat, lon, radius = marsRadius) {
+  const latRad = THREE.MathUtils.degToRad(lat);
+  const lonRad = THREE.MathUtils.degToRad(lon);
+  const x = radius * Math.cos(latRad) * Math.sin(lonRad);
+  const y = radius * Math.sin(latRad);
+  const z = radius * Math.cos(latRad) * Math.cos(lonRad);
+  return new THREE.Vector3(x, y, z);
+}
+
+function setStatus(message, timeout = 2200) {
+  statusMessage.textContent = message;
+  if (timeout) {
+    setTimeout(() => {
+      if (statusMessage.textContent === message) {
+        statusMessage.textContent = '';
+      }
+    }, timeout);
+  }
+}
+
+function clearInputs() {
+  nameInput.value = '';
+  latInput.value = '';
+  lonInput.value = '';
+  lastHitPoint = null;
+  setStatus('已清空当前输入。');
+}
+
+function highlightMarker(marker) {
+  if (selectedMarker && selectedMarker !== marker) {
+    selectedMarker.scale.set(1, 1, 1);
+  }
+  selectedMarker = marker;
+  if (marker) {
+    marker.scale.set(1.4, 1.4, 1.4);
+  }
+}
+
+function createMarkerMesh() {
+  const geometry = new THREE.SphereGeometry(0.05, 16, 16);
+  const material = new THREE.MeshStandardMaterial({
+    color: '#ff7043',
+    emissive: '#ff7043',
+    emissiveIntensity: 0.7,
+    roughness: 0.4,
+    metalness: 0.1,
+  });
+  return new THREE.Mesh(geometry, material);
+}
+
+function ensurePreview(markerData, elements) {
+  const { media } = markerData;
+  const { preview } = elements;
+  if (!media) {
+    preview.style.display = 'none';
+    preview.replaceChildren();
+    return;
+  }
+  const wrapper = document.createElement(media.type.startsWith('video') ? 'video' : 'img');
+  wrapper.src = media.url;
+  if (wrapper.tagName === 'VIDEO') {
+    wrapper.controls = true;
+    wrapper.loop = true;
+  }
+  preview.replaceChildren(wrapper);
+  preview.style.display = 'block';
+}
+
+function createCard(marker) {
+  const { id, name, lat, lon, notes } = marker.userData;
+  const card = document.createElement('div');
+  card.className = 'place-card';
+  card.dataset.markerId = id;
+  card.style.right = '24px';
+  card.style.bottom = '28px';
+
+  const header = document.createElement('header');
+  const title = document.createElement('h3');
+  title.textContent = name || '未命名地标';
+  const closeButton = document.createElement('button');
+  closeButton.className = 'close';
+  closeButton.innerHTML = '&times;';
+  closeButton.addEventListener('click', () => {
+    card.remove();
+    highlightMarker(null);
+  });
+  header.append(title, closeButton);
+
+  const coordField = document.createElement('div');
+  coordField.className = 'card-field';
+  coordField.textContent = `纬度 ${lat.toFixed(2)}° · 经度 ${lon.toFixed(2)}°`;
+
+  const uploadLabel = document.createElement('label');
+  uploadLabel.className = 'upload-area';
+  uploadLabel.textContent = '上传图片或视频';
+  const fileInput = document.createElement('input');
+  fileInput.type = 'file';
+  fileInput.accept = 'image/*,video/*';
+  uploadLabel.appendChild(fileInput);
+
+  const preview = document.createElement('div');
+  preview.className = 'preview-area';
+
+  const textarea = document.createElement('textarea');
+  textarea.placeholder = '在此输入关于此地名的描述、科研记录或勘察日志...';
+  textarea.value = notes || '';
+
+  fileInput.addEventListener('change', () => {
+    const file = fileInput.files?.[0];
+    if (!file) {
+      if (marker.userData.media?.url) {
+        URL.revokeObjectURL(marker.userData.media.url);
+      }
+      marker.userData.media = null;
+      ensurePreview(marker.userData, { preview });
+      updateListItem(id);
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    if (marker.userData.media?.url) {
+      URL.revokeObjectURL(marker.userData.media.url);
+    }
+    marker.userData.media = {
+      name: file.name,
+      type: file.type,
+      url,
+    };
+    ensurePreview(marker.userData, { preview });
+    updateListItem(id);
+  });
+
+  textarea.addEventListener('input', () => {
+    marker.userData.notes = textarea.value;
+    updateListItem(id);
+  });
+
+  ensurePreview(marker.userData, { preview });
+
+  card.append(header, coordField, uploadLabel, preview, textarea);
+  cardLayer.replaceChildren(card);
+}
+
+function updateListItem(id) {
+  const marker = markers.get(id);
+  if (!marker) return;
+  const item = placeList.querySelector(`[data-marker-id="${id}"]`);
+  if (!item) return;
+  const nameText = item.querySelector('.name-text');
+  nameText.textContent = marker.userData.name || '未命名地标';
+  const meta = item.querySelector('.place-meta');
+  meta.textContent = `纬度 ${marker.userData.lat.toFixed(2)}° · 经度 ${marker.userData.lon.toFixed(2)}°`;
+  const mediaBadge = item.querySelector('.media-badge');
+  if (marker.userData.media) {
+    mediaBadge.textContent = marker.userData.media.type.startsWith('video') ? '含视频' : '含图片';
+    mediaBadge.style.display = 'inline-flex';
+  } else {
+    mediaBadge.style.display = 'none';
+  }
+  const notesBadge = item.querySelector('.notes-badge');
+  if (marker.userData.notes?.trim()) {
+    notesBadge.style.display = 'inline-flex';
+    notesBadge.textContent = '已记录';
+  } else {
+    notesBadge.style.display = 'none';
+  }
+}
+
+function addToList(marker) {
+  const { id, name, lat, lon } = marker.userData;
+  const item = document.createElement('li');
+  item.dataset.markerId = id;
+
+  const nameRow = document.createElement('div');
+  nameRow.className = 'name-row';
+  const title = document.createElement('strong');
+  title.className = 'name-text';
+  title.textContent = name || '未命名地标';
+  const statusDot = document.createElement('span');
+  statusDot.className = 'status-dot';
+  nameRow.append(title, statusDot);
+
+  const meta = document.createElement('div');
+  meta.className = 'place-meta';
+  meta.textContent = `纬度 ${lat.toFixed(2)}° · 经度 ${lon.toFixed(2)}°`;
+
+  const badgeRow = document.createElement('div');
+  badgeRow.className = 'place-meta';
+  badgeRow.style.gap = '8px';
+
+  const mediaBadge = document.createElement('span');
+  mediaBadge.className = 'media-badge';
+  mediaBadge.style.display = 'none';
+  mediaBadge.style.padding = '2px 8px';
+  mediaBadge.style.borderRadius = '999px';
+  mediaBadge.style.background = 'rgba(255, 111, 60, 0.15)';
+  mediaBadge.style.color = '#ffedd5';
+  badgeRow.append(mediaBadge);
+
+  const notesBadge = document.createElement('span');
+  notesBadge.className = 'notes-badge';
+  notesBadge.style.display = 'none';
+  notesBadge.style.padding = '2px 8px';
+  notesBadge.style.borderRadius = '999px';
+  notesBadge.style.background = 'rgba(148, 163, 184, 0.15)';
+  notesBadge.style.color = '#e2e8f0';
+  badgeRow.append(notesBadge);
+
+  const actionRow = document.createElement('div');
+  actionRow.className = 'place-actions';
+
+  const focusButton = document.createElement('button');
+  focusButton.className = 'secondary';
+  focusButton.textContent = '聚焦';
+  focusButton.addEventListener('click', () => {
+    focusOnMarker(marker);
+  });
+
+  const cardButton = document.createElement('button');
+  cardButton.className = 'secondary';
+  cardButton.textContent = '打开卡片';
+  cardButton.addEventListener('click', () => {
+    openMarkerCard(marker);
+  });
+
+  actionRow.append(focusButton, cardButton);
+  item.append(nameRow, meta, badgeRow, actionRow);
+  placeList.appendChild(item);
+}
+
+function focusOnMarker(marker) {
+  const target = marker.position.clone();
+  controls.target.copy(target);
+  camera.position.copy(target.clone().multiplyScalar(1.8));
+  controls.update();
+  openMarkerCard(marker);
+}
+
+function openMarkerCard(marker) {
+  highlightMarker(marker);
+  createCard(marker);
+}
+
+function addMarker(name, lat, lon) {
+  const resolvedName = name || '未命名地标';
+  const position = fromLatLon(lat, lon, marsRadius * 1.02);
+  const marker = createMarkerMesh();
+  marker.position.copy(position);
+  const id = `marker-${++markerSequence}`;
+  marker.userData = {
+    id,
+    name: resolvedName,
+    lat,
+    lon,
+    notes: '',
+    media: null,
+  };
+  markerGroup.add(marker);
+  markers.set(id, marker);
+  addToList(marker);
+  setStatus(`已创建地名：${resolvedName}`);
+  return marker;
+}
+
+function handleCreateMarker() {
+  const name = nameInput.value.trim();
+  const lat = Number.parseFloat(latInput.value);
+  const lon = Number.parseFloat(lonInput.value);
+  if (Number.isNaN(lat) || Number.isNaN(lon)) {
+    setStatus('请先输入有效的经纬度。');
+    return;
+  }
+  if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+    setStatus('纬度范围 -90~90，经度范围 -180~180。');
+    return;
+  }
+  const marker = addMarker(name, lat, lon);
+  openMarkerCard(marker);
+  nameInput.value = '';
+}
+
+createButton.addEventListener('click', handleCreateMarker);
+clearButton.addEventListener('click', clearInputs);
+
+function handlePointerDown(event) {
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+
+  raycaster.setFromCamera(pointer, camera);
+
+  const markerHits = raycaster.intersectObjects(markerGroup.children, true);
+  if (markerHits.length > 0) {
+    const marker = markerHits[0].object;
+    openMarkerCard(marker);
+    return;
+  }
+
+  const hits = raycaster.intersectObject(marsMesh);
+  if (hits.length === 0) return;
+  lastHitPoint = hits[0].point.clone();
+  const { lat, lon } = toLatLon(lastHitPoint);
+  latInput.value = lat.toFixed(4);
+  lonInput.value = lon.toFixed(4);
+  setStatus(`已选择火星坐标：纬度 ${lat.toFixed(2)}°，经度 ${lon.toFixed(2)}°`);
+}
+
+renderer.domElement.addEventListener('pointerdown', handlePointerDown);
+
+function animate() {
+  requestAnimationFrame(animate);
+  marsMesh.rotation.y += 0.0006;
+  controls.update();
+  renderer.render(scene, camera);
+}
+
+animate();


### PR DESCRIPTION
## Summary
- create a standalone 3D Mars simulator page with an interactive globe and orbit controls
- add a control console for naming custom locations and managing marker cards with media uploads and notes
- provide styling for the simulator layout, marker list, and pop-up detail cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f517d3ee908331a11de4d032d09d44